### PR TITLE
Create tshark.sls

### DIFF
--- a/sift/packages/tshark.sl
+++ b/sift/packages/tshark.sl
@@ -1,0 +1,2 @@
+tshark:
+  pkg.installed


### PR DESCRIPTION
Useful tool in areas such as DFIR NetWars, at least one student was confused to find missing in the SIFT VM.