### PR TITLE
Updated version ot SQLite Miner

### DIFF
--- a/sift/scripts/sqlite_miner.sls
+++ b/sift/scripts/sqlite_miner.sls
@@ -1,9 +1,9 @@
 # source=https://github.com/threeplanetssoftware/sqlite_miner
 # license=GNUv3
 
-{% set commit     = "a475b7003942831c7c34d22311b4ef84237db92e" -%}
+{% set commit     = "4220dae48a6e45c1316b153231dc6beef36f2f59" -%}
 {% set hash_fun   = "sha256=c2e887dc62cb8191e0333f95d2e0eee330f62a778abf394f2ae158be39e44590" -%}
-{% set hash_miner = "sha256=efb7150f346fc8db768400dbcfa2ddcae0d2be44562d3cf88c814e494f5758d5" -%}
+{% set hash_miner = "sha256=19ed304989d7963b80530367caf4113810a55910147a7af41160d7f584614505" -%}
 
 include:
   - sift.packages.perl


### PR DESCRIPTION
This reflects the latest changes from today to let SQLite Miner support how SIFT is trying to call it (as a global, vice from a specific working directory). Most recent SQLite Miner commit is: https://github.com/threeplanetssoftware/sqlite_miner/tree/4220dae48a6e45c1316b153231dc6beef36f2f59

This does *not* yet address the fact that the needed CPAN module DBI is not installed, but at least lets SQLite Miner work if the user installs that manually.