### PR TITLE
Updated README to correct copy/paste typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ sudo salt-call -l info --local --file-root=/tmp/salt state.apply sift.pkgs
 ### 18.04
 
 1. `wget -O - https://repo.saltstack.com/apt/ubuntu/18.04/amd64/latest/SALTSTACK-GPG-KEY.pub | sudo apt-key add -`
-2. `echo "deb http://repo.saltstack.com/apt/ubuntu/18.04/amd64/2018.3 xenial main" | sudo tee /etc/apt/sources.list.d/saltstack.list`
+2. `echo "deb http://repo.saltstack.com/apt/ubuntu/18.04/amd64/2018.3 bionic main" | sudo tee /etc/apt/sources.list.d/saltstack.list`
 3. `sudo apt-get update`
 4. `sudo apt-get install salt-minion`
 5. `sudo service salt-minion stop`


### PR DESCRIPTION
When 18.04 was added the repo information for 16.04 was copied, including the word 'xenial'. '16.04' was changed to '18.04', but 'xenial' was never updated to 'bionic'. This simply changes that word so that the saltstack apt updates work.