### PR TITLE
Perl Module Support

### DIFF
--- a/sift/perl-packages/datecalc.sls
+++ b/sift/perl-packages/datecalc.sls
@@ -1,0 +1,8 @@
+include:
+  - sift.packages.perl
+
+datecalc:
+  pkg.installed:
+    - name: libdate-calc-perl
+    - require:
+      - sls: sift.packages.perl

--- a/sift/perl-packages/dbi.sls
+++ b/sift/perl-packages/dbi.sls
@@ -1,0 +1,8 @@
+include:
+  - sift.packages.perl
+
+dbi:
+  pkg.installed:
+    - name: libdbi-perl
+    - require:
+      - sls: sift.packages.perl

--- a/sift/perl-packages/exiftool.sls
+++ b/sift/perl-packages/exiftool.sls
@@ -1,0 +1,8 @@
+include:
+  - sift.packages.perl
+
+exiftool:
+  pkg.installed:
+    - name: libimage-exiftool-perl
+    - require:
+      - sls: sift.packages.perl

--- a/sift/perl-packages/init.sls
+++ b/sift/perl-packages/init.sls
@@ -1,0 +1,10 @@
+include:
+  - sift.perl-packages.dbi
+  - sift.perl-packages.json
+
+sift-perl-packages:
+  test.nop:
+    - name: sift-perl-packages
+    - require:
+      - sls: sift.perl-packages.dbi
+      - sls: sift.perl-packages.json

--- a/sift/perl-packages/init.sls
+++ b/sift/perl-packages/init.sls
@@ -1,10 +1,16 @@
 include:
+  - sift.perl-packages.datecalc
   - sift.perl-packages.dbi
+  - sift.perl-packages.exiftool
   - sift.perl-packages.json
+  - sift.perl-packages.xpath
 
 sift-perl-packages:
   test.nop:
     - name: sift-perl-packages
     - require:
+      - sls: sift.perl-packages.datecalc
       - sls: sift.perl-packages.dbi
+      - sls: sift.perl-packages.exiftool
       - sls: sift.perl-packages.json
+      - sls: sift.perl-packages.xpath

--- a/sift/perl-packages/json.sls
+++ b/sift/perl-packages/json.sls
@@ -1,0 +1,8 @@
+include:
+  - sift.packages.perl
+
+json:
+  pkg.installed:
+    - name: libjson-perl
+    - require:
+      - sls: sift.packages.perl

--- a/sift/perl-packages/xpath.sls
+++ b/sift/perl-packages/xpath.sls
@@ -1,0 +1,8 @@
+include:
+  - sift.packages.perl
+
+xpath:
+  pkg.installed:
+    - name: libxml-xpath-perl
+    - require:
+      - sls: sift.packages.perl

--- a/sift/scripts/sqlite_miner.sls
+++ b/sift/scripts/sqlite_miner.sls
@@ -1,9 +1,9 @@
 # source=https://github.com/threeplanetssoftware/sqlite_miner
 # license=GNUv3
 
-{% set commit     = "a475b7003942831c7c34d22311b4ef84237db92e" -%}
+{% set commit     = "4220dae48a6e45c1316b153231dc6beef36f2f59" -%}
 {% set hash_fun   = "sha256=c2e887dc62cb8191e0333f95d2e0eee330f62a778abf394f2ae158be39e44590" -%}
-{% set hash_miner = "sha256=efb7150f346fc8db768400dbcfa2ddcae0d2be44562d3cf88c814e494f5758d5" -%}
+{% set hash_miner = "sha256=19ed304989d7963b80530367caf4113810a55910147a7af41160d7f584614505" -%}
 
 include:
   - sift.packages.perl
@@ -32,3 +32,4 @@ sift-scripts-sqlite-miner-shebang:
     - text: '#!/usr/bin/env perl'
     - watch:
       - file: sift-scripts-sqlite-miner
+

--- a/sift/server.sls
+++ b/sift/server.sls
@@ -2,6 +2,7 @@ include:
   - sift.repos
   - sift.packages
   - sift.python-packages
+  - sift.perl-packages
   - sift.scripts
 
 sift-server-version-file:
@@ -14,4 +15,5 @@ sift-server-version-file:
       - sls: sift.repos
       - sls: sift.packages
       - sls: sift.python-packages
+      - sls: sift.perl-packages
       - sls: sift.scripts


### PR DESCRIPTION
This branch starts fixing the issues raised in #249 and #263. It adds Perl module support in a method similar to the Python module support, by creating a folder (perl-packages) that has each module inside of it. While this does not use the `cpan.installed` module that saltstack should have, that is because I couldn't get that to work in this environment. Instead this uses the normal Ubuntu package manager to install the modules. 

This will fix the following tools:
- docx-font-extractor.pl XML/XPath.pm
- fb.pl JSON.pm
- ff.pl DBI.pm
- ff_signons.pl DBI.pm
- json-printer.pl JSON.pm
- squirrelgripper.pl DBI.pm, also requires ExifTool
- timediff32.pl Date/Calc.pm
- vmail-db-2-html.pl DBI.pm