### PR TITLE
Fixed the rest of the Perl modules

### DIFF
--- a/sift/config/tools/init.sls
+++ b/sift/config/tools/init.sls
@@ -1,8 +1,12 @@
 include:
   - sift.config.tools.foremost
+  - sift.config.tools.perl-modules
+  - sift.config.tools.windows-forensic-analysis
   
 sift-config-tools:
   test.nop:
     - name: sift-config-tools
     - require:
       - sls: sift.config.tools.foremost
+      - sls: sift.config.tools.perl-modules
+      - sls: sift.config.tools.windows-forensic-analysis

--- a/sift/config/tools/perl-modules.sls
+++ b/sift/config/tools/perl-modules.sls
@@ -1,0 +1,10 @@
+include:
+  - sift.packages.perl
+
+sift-perl-html-quicktable:
+  file.managed:
+    - name: /usr/share/perl5/QuickTable.pm
+    - source: salt://sift/files/perl-modules/QuickTable.pm
+    - required:
+      - sls: sift.packages.perl
+

--- a/sift/config/tools/windows-forensic-analysis.sls
+++ b/sift/config/tools/windows-forensic-analysis.sls
@@ -1,0 +1,23 @@
+include:
+  - sift.packages.perl
+
+sift-tools-windows-forensic-analysis-jumplist:
+  file.managed:
+    - name: /usr/share/perl5/JumpList.pm
+    - source: salt://sift/files/windows-forensic-analysis/JumpList.pm
+    - required:
+      - sls: sift.packages.perl
+
+sift-tools-windows-forensic-analysis-lnk:
+  file.managed:
+    - name: /usr/share/perl5/LNK.pm
+    - source: salt://sift/files/windows-forensic-analysis/LNK.pm
+    - required:
+      - sls: sift.packages.perl
+
+sift-tools-windows-forensic-analysis-pref:
+  file.managed:
+    - name: /usr/share/perl5/Pref.pm
+    - source: salt://sift/files/windows-forensic-analysis/pref.pm
+    - required:
+      - sls: sift.packages.perl

--- a/sift/files/perl-modules/QuickTable.pm
+++ b/sift/files/perl-modules/QuickTable.pm
@@ -1,0 +1,811 @@
+
+package HTML::QuickTable;
+
+=head1 NAME
+
+HTML::QuickTable - Quickly create fairly complex HTML tables
+
+=head1 SYNOPSIS
+
+    use HTML::QuickTable;
+
+    my $qt = HTML::QuickTable->new(
+                   table_width  => '95%',       # opt method 1
+                   td => {bgcolor => 'gray'},   # opt method 2
+                   font_face => 'arial',        # set font
+                   font => {face => 'arial'},   # same thing
+                   labels => 1,                 # make top <th>?
+                   stylesheet => 1,             # use stylesheet?
+                   styleclass => 'mytable',     # class to use
+                   useid  => 'results',         # id="results_r1c2" etc
+                   header => 0,                 # print header?
+             );
+
+    my $table1 = $qt->render(\@array_of_data);
+
+    my $table2 = $qt->render(\%hash_of_keys_and_values);
+
+    my $table3 = $qt->render($object_with_param_method);
+
+=cut
+
+use Carp;
+use strict;
+use vars qw($VERSION %INDENT);
+
+$VERSION = do { my @r=(q$Revision: 1.12 $=~/\d+/g); sprintf "%d."."%02d"x$#r,@r };
+%INDENT  = (
+   table => 0,
+   tr    => 1,
+   th    => 2,
+   td    => 2,
+);
+
+sub _expopts {
+    # This is a general-purpose option-parsing routine that
+    # puts stuff down one level if it has a _ in it; this
+    # allows stuff like "td_height => 50" and "td => {height => 50}"
+    my $lev = shift || 0;
+    my %opt = ();
+    $lev++;
+    while (@_) {
+        my $key = shift;
+        my $val = shift;
+        if ($key =~ /^([a-zA-Z0-9]+)_(.*)/) {
+            # looks like "td_height" or "font_face"
+            $opt{$1}{$2} = $val;
+        } elsif (ref $val eq 'HASH') {
+            # this allows "table => {width => '95%'}"
+            $opt{$key} = _expopts($lev, %$val);
+        } elsif ($key eq 'font' && $lev == 1) {
+            # special catch for two options to be FormBuilder-like
+            $opt{font}{face} = $val;
+        } elsif ($key eq 'lalign' && $lev == 1) {
+            $opt{th}{align} = $val;
+        } elsif ($key eq 'border' && $lev == 1) {
+            # useful shortcut
+            $opt{table}{border} = $val;
+        } else {
+            # put regular options in the top-level space
+            $opt{$key} = $val;
+        }
+    }
+    $lev--;
+    return wantarray ? %opt : \%opt;
+}
+
+sub new {
+    my $self = shift;
+    my $class = ref($self) || $self;
+    my %opt = _expopts(0, @_);
+
+    # counters
+    $opt{_level} = 0;
+    $opt{_sentheader} = 0;
+
+    # special options
+    $opt{table}{border} = delete $opt{border} if exists $opt{border};  # legacy
+    $opt{body} ||= {bgcolor => 'white'};
+    $opt{null} ||= '';      # prevents warnings
+
+    # stylesheet handling
+    if ($opt{stylesheet}) {
+        $opt{styleclass} ||= 'qt';
+        delete $opt{font};  # kill font
+    }
+
+    # setup our font tag separately
+    # do this here or else every call to render() must do it
+    ($opt{_fo}, $opt{_fc}) = $opt{font}
+                                ? (_tag('font', %{$opt{font}}), '</font>')
+                                : ('','');
+
+    return bless \%opt, $class;
+}
+
+# Internal tag routines stolen from CGI::FormBuilder, which
+# in turn stole them from CGI.pm
+
+sub _escapeurl ($) {
+    # minimalist, not 100% correct, URL escaping
+    my $toencode = shift || return undef;
+    $toencode =~ s!([^a-zA-Z0-9_,.-/])!sprintf("%%%02x",ord($1))!eg;
+    return $toencode;
+}
+
+sub _escapehtml ($) {
+    defined(my $toencode = shift) or return '';
+    eval { require  HTML::Entities };
+    if ($@) {
+        # not found; use very basic built-in HTML escaping
+        $toencode =~ s!&!&amp;!g;
+        $toencode =~ s!<!&lt;!g;
+        $toencode =~ s!>!&gt;!g;
+        $toencode =~ s!"!&quot;!g;
+        return $toencode;
+    } else {
+        # dispatch to HTML::Entities
+        return HTML::Entities::encode($toencode);
+    }
+    return $toencode;
+}
+
+sub _tag ($;@) {
+    # called as _tag('tagname', %attr)
+    # creates an HTML tag on the fly, quick and dirty
+    my $name = shift || return;
+    my @tag;
+    my %saw = ();   # prevent dups
+    while (@_) {
+        # this cleans out all the internal junk kept in each data
+        # element, returning everything else (for an html tag)
+        my $key = lc shift;
+        my $val = _escapehtml shift;    # minimalist HTML escaping
+        push @tag, qq($key="$val") unless $saw{$key}++;
+    }
+    return '<' . join(' ', $name, sort @tag) . '>';
+}
+
+sub _tohtml ($) {
+    defined(my $text = shift) or return;
+
+    # Need to catch the < and > commonly used in emails
+    $text = _escapehtml($text);
+
+    # A couple little catches
+    $text =~ s!\*([^\*]+)\*!<b>$1</b>!g;
+    $text =~ s!\_([^\_]+)\_!<i>$1</i>!g;
+
+    # Also catch links - remember there are a LOT of assumptions here!!!
+    $text =~ s!(http[s]?://[\=\.\-\/\w+\?]+)(\s+)!<a href="$1">$1</a>$2!g;
+    $text =~ s!([\w\.\-\+\_]+\@[\w\-\.]+)!<a href="mailto:$1">$1</a>!g;       # email addrs
+
+    return $text;
+}
+
+sub _toname ($) {
+    # creates a name from a var/file name (like file2name)
+    my $name = shift;
+    $name =~ s!\.\w+$!!;        # lose trailing ".cgi" or whatever
+    $name =~ s![^a-zA-Z0-9.-/]+! !g;
+    $name =~ s!\b(\w)!\u$1!g;
+    return $name;
+}
+
+# These handle styleclass and id generation, if requested
+sub _getclass {
+    my $self = shift;
+    return '' unless $self->{stylesheet};
+    my $row  = shift || 0;  # is a row
+
+    # if styleclass is an array, alternate between
+    my $class = '';
+    if (ref $self->{styleclass} eq 'ARRAY') {
+        if ($row && $self->{_notfirstrow}) {   # only alternate rows
+            push @{$self->{_tmpclass}||=[]}, shift @{$self->{styleclass}};
+            unless (@{$self->{styleclass}}) {
+                # have pushed thru all, so start over
+                $self->{styleclass} = delete $self->{_tmpclass};
+            }
+        }
+        $class = $self->{styleclass}[0];
+    } else {
+        $class = $self->{styleclass};
+    }
+    return $class;
+}
+
+# Generate a unique id for each element
+sub _getid {
+    my $self = shift;
+    return '' unless $self->{useid};
+    my $base = join '', @_;  # rest is 'r', 42, 'c', 15, etc
+    return $base ? "$self->{useid}_$base" : $self->{useid};
+}
+
+# Keep track of the appropriate indent
+sub _indent {
+    local $^W = 0;
+    my $self = shift;
+    my $what = shift;   # element name
+    return '  ' x $INDENT{$what};
+    my $last = $self->{_lastidt} || '';
+    if (! $last) {
+        # first layer
+        $self->{_indent} = 0;
+    } elsif ($what eq $last) {
+        # nothing, same
+        $self->{_indent} ||= 0
+    } elsif ($INDENT{$what} > $INDENT{$last}) {
+        # use it as a base
+        $self->{_indent}++;
+    } elsif ($INDENT{$what} < $INDENT{$last}) {
+        # we're nesting
+        $self->{_indent}--;
+    }
+    $self->{_lastidt} = $what;
+    return '  ' x ($self->{_indent} * $INDENT{$last});
+}
+
+# This recursively renders a data structure into a table
+sub render {
+    # Do the work and return as a scalar
+    my $self = shift;
+    my($data, $html) = ('','');
+    my $ref = ref $_[0];
+    if (@_ > 1) {
+        # assume that it's an array
+        $ref = 'ARRAY';
+        $data = [ @_ ]; 
+    } elsif ($ref) {
+        # shift it
+        $data = shift;
+    } elsif (! $self->{_level}) {
+        croak '[HTML::QuickTable] Argument to render() must be \@array, \%hash, or $object';
+    } else {
+        $ref = 'ARRAY';
+        $data = [ @_ ]; 
+    }
+
+    # We expand data differently depending on what type of structure it is
+    # Truthfully, all this sub can handle is arrayrefs. Everything else
+    # is converted on the fly by the "else" statement to an arrayref and
+    # this sub is recursively called.
+
+    if ($ref eq 'ARRAY') {
+
+        # create our opening table tag
+        my $tab = $self->{_level} ? {width => '100%'} : $self->{table};
+        $tab->{id}    = $self->_getid    if $self->{useid};
+        $tab->{class} = $self->_getclass if $self->{stylesheet};
+        $html .= _tag('table', %$tab) . "\n" unless ++$self->{_level} == 2;
+
+        my @tmprow = ();
+        if ($self->{vertical} && ref $data->[0] eq 'ARRAY') {
+            # Whole different algorithm, here we must iterate in a column-
+            # based manner, not a row-based one. This means walking the
+            # array "backwards". Notice the for loops iterate inside-out.
+            for (my $ci=0; $ci < @{$data->[0]}; $ci++) {
+                $tmprow[$ci] = [];
+                for (my $ri=0; $ri < @$data; $ri++) {
+                    push @{$tmprow[$ci]}, $data->[$ri][$ci]; 
+                }
+            }
+        } else {
+            # non-vertical or already expanded/rearranged
+            @tmprow = @$data;
+        }
+
+        # Now, walk all arrays in the same manner, since vert's were rearranged
+        my $colnum = 0;
+        $self->{_rownum} ||= 0;
+        for my $row (@tmprow) {
+            unless ($self->{_level} == 2) {
+                $self->{tr}{id}    = $self->_getid('r', ++$self->{_rownum}) if $self->{useid};
+                $self->{tr}{class} = $self->_getclass(1) if $self->{stylesheet};
+                $html .= ' ' . _tag('tr', %{$self->{tr}}) . "\n";
+            }
+            if ($self->{_level} == 1) {
+                $html .= $self->render($row);
+            }
+            else {
+                # For an array, we do not generate <th> each time, only the first
+                # time per the row/column
+                my $td = 'td';
+                if (my $l = $self->{labels}) {
+                    if (($l =~ /[1T]/i && ! $self->{_notfirstrow})
+                      || ($l =~ /L/i && ! $colnum)
+                      || ($l =~ /R/i && $colnum == (@tmprow-1))
+                    ) {
+                        $td = 'th';
+                    } elsif ($l =~ /B/i) {
+                        croak "[HTML::QuickTable] Sorry, labels => 'B' is broken - want to patch it?";
+                    }
+                }
+
+                # Catch td class stuff
+                $self->{$td}{id}    = $self->_getid('r', $self->{_rownum}, 'c', $colnum+1) if $self->{useid};
+                $self->{$td}{class} = $self->_getclass if $self->{stylesheet};
+
+                # Recurse data structures
+                if (ref $row) {
+                    $html .= '  ' . _tag($td, %{$self->{$td}}) . $self->{_fo} 
+                                  . $self->render($row) . $self->{_fc} . "</$td>\n";
+                }
+                else {
+                    $row = _toname($row) if $self->{nameopts} && $td eq 'th';
+                    $row = _tohtml($row) if $self->{htmlize};
+                    my $tdptr = $self->{$td};
+                    unless (defined $row) {
+                        # "null", so alter HTML accordingly
+                        $row = $self->{null};
+                        $tdptr = $self->{nulltags} if $self->{nulltags};
+                        $tdptr->{id}    = $self->_getid('r', $self->{_rownum}, 'c', $colnum+1) if $self->{useid};
+                        $tdptr->{class} ||= $self->_getclass if $self->{stylesheet};
+                    }
+                    $html .= '  ' . _tag($td, %{$tdptr}) . $self->{_fo}
+                                  . $row . $self->{_fc} . "</$td>\n";
+                }
+            }
+            unless ($self->{_level} == 2) {
+                $html .= " </tr>\n";
+            }
+            $colnum++;
+        }
+        $html .= '</table>' unless $self->{_level}-- == 2 ;
+
+    } else {
+
+        # Must expand the data structure carefully
+        if ($ref eq 'HASH') {
+            # This assumes that the data struct is consistent; we cannot
+            # handle any other kind because of our assumptions
+            # Guess struct based on the first key we see
+            my $key = each %$data;
+            my @new = ();
+            if (ref $data->{$key} eq 'HASH') {
+                # keylabel => {colname => value, colname => value}
+
+                # this bit of "pre-scanning" gets all the available
+                # column names in our data
+                my %cols;
+                my @rows = sort keys %$data;
+                for my $row (@rows) {
+                    $cols{$_}++ for keys %{$data->{$row}};
+                } 
+
+                # Now that we have a list of all our columns, we must
+                # re-iterate through all our rows (again!) to get vals
+                my @cols = sort keys %cols;
+                for my $row (@rows) {
+                    my @thisrow = ();
+                    for my $col (@cols) {
+                        $data->{$row}{$col} ||= undef;  # causes autoviv
+                        #if (ref $data->{$row}{$col} &&
+                            #ref $data->{$row}{$col} ne 'ARRAY')
+                        #{
+                            # recursively call for refs
+                            #push @thisrow, $self->render($data->{$row}{$col});
+                        #} else {
+                            #my $val = ref $data->{$row}{$col} eq 'ARRAY'
+                                            #? $data->{$row}{$col} : [$data->{$row}{$col}];
+                            #push @thisrow, [$row, @$val];
+                            push @thisrow, $data->{$row}{$col};
+                        #}
+                    }
+                    push @new, [$row, @thisrow];
+                }
+                my $keylabel = $self->{keylabel} || '';
+                unshift @new, [$keylabel, @cols];
+            }
+            elsif (ref $data->{$key} eq 'ARRAY' || ! ref $data->{$key}) {
+                # keylabel => [value, value, value] or keylabel => value
+
+                for my $row (sort keys %$data) {
+                    my $val = ref $data->{$row} eq 'ARRAY' ? $data->{$row} : [$data->{$row}];
+                    push @new, [$row, @$val];
+                }
+            }
+            # both methods above will fill up @new
+            $html .= $self->render(\@new);
+        }
+        elsif ($ref && UNIVERSAL::can($ref, 'param')) {
+            # object with param method
+            my @keys = $data->param;
+            $self->{labels} = 1;
+            my @new = ();
+            for my $key (@keys) {
+                my(@val) = $data->param($key);
+                my $val  = @val > 1 ? \@val : $val[0];
+                push @new, $val;
+            }
+            $data = [\@keys, \@new];
+            $html .= $self->render($data);
+        }
+    }
+
+    if ($self->{header} && ! $self->{_level} && ! $self->{_sentheader}++) {
+        my $title = $self->{title} ? ('<title>'._escapehtml($self->{title})."</title>\n") : '';
+        my $h3    = $self->{title} ? "<h3>$self->{title}</h3>\n" : '';
+        my $style = ($self->{stylesheet} && $self->{stylesheet} ne 1)
+                        ? qq(<link rel="stylesheet" href="$self->{stylesheet}" />\n) : '';
+        my $text  = $self->{text} ? "$self->{text}\n" : '';
+
+        $html = "Content-type: text/html; charset=iso-8859-1\n\n" . '<html>'    # fuck doctypes, really
+              . "\n" . _tag('head', %{$self->{head}}) . "\n" . $style . $title . "</head>\n"
+              . _tag('body', %{$self->{body}}) . $self->{_fo} . "\n" 
+              . $h3 . $text . $html . $self->{_fc} . "</body></html>\n";
+    }
+
+    # detect what row we're in by counting down and up
+    $self->{_notfirstrow} = $self->{_level};
+
+    return $html;
+}
+
+1;
+
+__END__
+
+=head1 DESCRIPTION
+
+This modules lets you easily create HTML tables. Like B<CGI::FormBuilder>,
+this module does a lot of thinking for you. For a comprehensive
+module that gives you the ability to tweak every aspect of table building,
+see B<HTML::Table> or B<Data::Table>. This one gives you a lot of control,
+but is really designed as an easy way to expand arbitrary data structures.
+
+The simplest table can be created with nothing more than:
+
+    my $qt = HTML::QuickTable->new;
+    print $qt->render(\@data);
+
+Where C<@data> would be an array holding your data structure. For example,
+the data structure:
+
+    @data = (
+        [ 'nwiger', 'Nathan Wiger', 'x43264', 'nate@wiger.org' ],
+        [ 'jbobson', 'Jim Bobson', 'x92811', 'jim@bobson.com' ]
+    );
+
+Would be rendered as something like:
+
+    <table>
+    <tr><td>nwiger</td><td>Nathan Wiger</td><td>x43264</td><td>nate@wiger.org</td></tr>
+    <tr><td>jbobson</td><td>Jim Bobson</td><td>x92811</td><td>jim@bobson.com</td></tr>
+    </table>
+
+Of course, the best use for this module is on dynamic data, say something
+like this:
+
+    use DBI;
+    use HTML::QuickTable;
+
+    my $qt = HTML::QuickTable->new(header => 1);    # print header
+    my $dbh = DBI->connect( ... );
+
+    my $all_arrayref = $dbh->selectall_arrayref("select * from billing");
+    
+    print $qt->render($all_arrayref);
+
+With C<< header => 1 >>, you will get a brief C<CGI> header as well as
+some basic C<HTML> to prettify things. As such, the above will print
+out all the rows that your query selected in an C<HTML> table.
+
+=head1 FUNCTIONS
+
+=head2 new(opt => val, opt => val)
+
+The C<new()> function takes a list of options and returns a C<$qt>
+object, which can then be used to C<render()> different data. The
+C<new()> function has a flexible options-parsing mechanism that 
+allows you to specify settings to pretty much any element of the
+table.
+
+Options include:
+
+=over
+
+=item header => 1 | 0
+
+If set to C<1>, a basic C<CGI> header and leading C<HTML> is printed
+out. Useful if you're really looking for quick and dirty. Defaults
+to C<0>.
+
+=item htmlize => 1 | 0
+
+If set to 1, then all values will be run through a simple filter that
+creates links for things that look like email addresses or websites.
+Also, C<*word*> will be changed to C<< <b>word</b> >>, and C<_word_>
+will be changed to C<< <i>word</i> >>.
+
+=item labels => 1 | 0 | LTRB
+
+If set to 1, then the first row of the data is used as the labels
+of the data columns, and is placed in C<< <th> >> tags. For example,
+if we assume our above data structure, and said:
+
+    my $qt = HTML::QuickTable->new(... labels => 1);
+
+    unshift @data, ['User', 'Name', 'Ext', 'Email'];
+
+    print $qt->render(\@data);
+
+You would get something like this:
+
+    <table>
+    <tr><th>User</th><th>Name</th><th>Ext</th><th>Email</th></tr>
+    <tr><td>nwiger</td><td>Nathan Wiger</td><td>x43264</td><td>nate@wiger.org</td></tr>
+    <tr><td>jbobson</td><td>Jim Bobson</td><td>x92811</td><td>jim@bobson.com</td></tr>
+    </table>
+
+Since the labels are placed in C<< <th> >> tags, you can then use
+the extra C<HTML> options described below to alter the way that the
+labels look. 
+
+You can also set this to a string that includes the characters
+L, T, R, and B, to specify that C<< <th> >> tags should be created
+for the Left, Top, Right, and Bottom rows and columns. So for example:
+
+    labels => 'LT'
+
+Would alter the table so that both the first row AND first column
+had C<< <th> >> instead of C<< <td> >> elements. This is useful
+for creating tables that have two axes, such as calendars.
+
+=item null => $string
+
+If set, then null (undef) fields will be set to that string instead.
+This is useful if pulling a bunch of records out of a database and
+not wanting to get blank table spaces everywhere there's a null field.
+For example:
+
+    my $qt = HTML::QuickTable->new(null => '-');
+    my $all_arrayref = $sth->fetchall_arrayref;
+    print $qt->render($all_arrayref);
+
+By default null table elements are left blank.
+
+=item nulltags => \%hash
+
+In addition to just changing the string used to represent null data,
+you may want to change the look of it as well. These tags will become
+attributes to the C<< <td> >> element holding the null field. So, 
+settings like this:
+
+    null => 'N/A',
+    nulltags => {bgcolor => 'gray'},
+
+Would result in an element like the following for null fields:
+
+    <td bgcolor="gray">N/A<td>
+
+Make sense?
+
+=item stylesheet => 1 | '/path/to/style.css'
+
+If set, then any font settings are ignored and instead all table
+elements are wrapped with a C<class=> attribute. The class name
+is whatever C<styleclass> is set to (see below). See also the
+C<useid> option to generate C<id> tags in an intelligent way.
+
+=item styleclass => $string | \@array
+
+This used as a style class to use if the above setting is used.
+If set to a string, it is passed directly to the C<class> tag.
+If set to an arrayref, then those styles are alternated between
+on a row-by-row (C<tr>) basis. For example:
+
+    styleclass => [qw(one two)]
+
+Would yield C<XHTML> similar to:
+
+    <table class="one">
+      <tr class="one">
+        <td class="one">a</td>
+        <td class="one">b</td>
+        <td class="one">c</td>
+        <td class="one">d</td>
+      </tr>
+      <tr class="two">
+        <td class="two">e</td>
+        <td class="two">f</td>
+        <td class="two">g</td>
+        <td class="two">h</td>
+      </tr>
+    </table>
+
+Notice that the table gets the style of the first array element.
+
+=item text => $string
+
+Just like B<FormBuilder>, this text is printed out for you to easily
+annotate your table.
+
+=item title => $string
+
+If you set C<< header => 1 >>, then you can also specify the C<title>
+to be prefixed to the document. Otherwise this option is ignored.
+
+=item useid => $baseid
+
+If set, then unique C<id> tags are automatically generated for each
+and every table element, allowing you to address the entire table
+on a per-element basis via Javascript or CSS. These tags take the
+format:
+
+    $baseid[_rX[cY]]
+
+Where C<X> is the row number and C<Y> is the column number. So
+this setting:
+
+    useid => 'results'
+
+Would yield C<XHTML> like:
+
+    <table id="results">
+      <tr id="results_r1">
+        <th id="results_r1c1">n1</th>
+        <th id="results_r1c2">n2</th>
+        <th id="results_r1c3">n3</th>
+        <th id="results_r1c4">n4</th>
+      </tr>
+      <tr id="results_r2">
+        <td id="results_r2c1">1</td>
+        <td id="results_r2c2">2</td>
+        <td id="results_r2c3">3</td>
+        <td id="results_r2c4">4</td>
+      </tr>
+    </table>
+
+Notice that the table gets the baseid verbatim.
+
+=item vertical => 1 | 0
+
+If you set this to 1, then it fundamentally changes the way in which
+data is expanded. Instead of walking the data structure and building
+rows horizontally, each element of data will become a column. This
+option is described more below under C<render()>.
+
+=item body => {opt => val, opt => val}
+
+=item font => {opt => val, opt => val}
+
+=item table => {opt => val, opt => val}
+
+=item td => {opt => val, opt => val}
+
+=item th => {opt => val, opt => val}
+
+=item tr => {opt => val, opt => val}
+
+These options can be used to set attributes to be used on the applicable
+tag. For example, if you wanted the table width to be C<95%> and the
+C<border> to be C<1>, you would say:
+
+    my $qt = HTML::QuickTable->new(table => {width => '95%', border => 1});
+
+Of course, you can specify as many different options as you want:
+
+    my $qt = HTML::QuickTable->new(table => {width => '95%', border => 1},
+                                   td    => {class => 'td_el'},
+                                   font  => {face => 'arial,helvetica'} );
+
+As an alternative form, you can also use:
+
+=item body_opt => val
+
+=item font_opt => val
+
+=item table_opt => val
+
+=item td_opt => val
+
+=item th_opt => val
+
+=item tr_opt => val
+   
+Instead of having to specify a hashref, you can use this option
+form to specify C<HTML> tags.  For example, if you want to set the
+font face, either of these will do the exact same thing:
+
+    my $qt = HTML::QuickTable->new(font => {face => 'verdana'});
+    my $qt = HTML::QuickTable->new(font_face => 'verdana');
+
+Again, you can specify any C<HTML> tag you want and it will get
+included. Anything after the underscore is taken as the tag
+name and placed into the output C<HTML> verbatim.
+
+=back
+
+=head2 render(\@data | \%data | $object) 
+
+The C<render()> function can accept either an C<arrayref>, C<hashref>,
+or C<object>. It then recursively expands the data per the options
+you specified to C<new()>. Each data structure is rendered differently:
+
+=over
+
+=item arrayref (\@array)
+
+An C<arrayref> should expand intuitively; each row in the array
+becomes another row in the table. If you specify the C<labels>
+option, then the first row is taken as the column labels and is
+placed within C<< <th> >> elements.
+
+=item object ($object)
+
+An C<object> also expands quite simply. First, the C<object>'s
+C<param()> method is called to get a list of keys. Then, for
+each key the value is placed in the array. The key is taken as
+the label for that column, and is placed within a C<< <th> >>.
+As an example, you can dump a nice table of your C<CGI> query with:
+
+    use CGI;
+    use HTML::QuickTable;
+
+    my $cgi = CGI->new;
+    my $qt  = HTML::QuickTable->new(header => 1);
+
+    print $qt->render($cgi); 
+
+=item hashref (\%hash)
+
+A C<hashref> is first sorted by C<key>. Then, each data element
+becomes a data element for that column. For example:
+
+    %user = (
+        'nwiger'  => ['Nathan Wiger', 'nate@wiger.org'],
+        'jbobson' => ['Jim Bobson', 'jim@bobson.com']
+    );
+
+    print $qt->render(\%user);
+
+Would be rendered as:
+
+    <table>
+    <tr><td>jbobson</td><td>Jim Bobson</td><td>jim@bobson.com</td></tr>
+    <tr><td>nwiger</td><td>Nathan Wiger</td><td>nate@wiger.org</td></tr>
+    </table>
+
+Note that it's very similar to the way arrays are handled. The benefit
+here is that this allows you to expand arbitrary data structures.
+
+If it's a C<hashref> of C<hashrefs>, for example:
+
+    %user = (
+        'nwiger'  => { name => 'Nathan Wiger', email => 'nate@wiger.org' },
+        'jbobson' => { name => 'Jim Bobson', email => 'jim@bobson.com'}
+    );
+
+    print $qt->render(\%user);
+
+Then some Major Magic (tm) happens and you'll get something like this:
+
+    <table>
+    <tr><th></th><th>email</th><th>name</th></tr>
+    <tr><td>jbobson</td><td>jim@bobson.com</td><td>Jim Bobson</td></tr>
+    <tr><td>nwiger</td><td>nate@wiger.org</td><td>Nathan Wiger</td></tr>
+    </table>
+
+Notice that the keys were sorted alphabetically and output in order.
+But, note that the top-level C<key> is not labeled in the C<< <th> >>.
+To change this, you must specify the C<keylabel> option to C<new()>:
+
+    my $qt = HTML::QuickTable->new(keylabel => 'user');
+    # ...
+    print $qt->render(\%user);
+
+That would create the same C<HTML> as above, except the first column
+label would be "user".
+
+=back
+
+=head1 NOTES
+
+The 'B' option to 'labels' is currently broken, due to the fact that
+C<render()> recursively calls itself and thus loses track of where
+it is. But who the heck puts labels at the I<bottom> of an HTML table??
+
+If you run into a bug, please DO NOT submit it via C<rt.cpan.org> - that
+just causes me alot of extra work. Email me at the below address, and
+include the version string your eyes are about to pass over.
+
+=head1 SEE ALSO
+
+L<HTML::Table>, L<Data::Table>, L<SQL::Abstract>, L<CGI::FormBuilder>
+
+=head1 VERSION
+
+$Id: QuickTable.pm,v 1.12 2005/05/10 21:10:52 nwiger Exp $
+
+=head1 AUTHOR
+
+Copyright (c) 2001-2005 Nathan Wiger <nate@wiger.org>. All Rights Reserved.
+
+This module is free software; you may copy this under the terms of
+the GNU General Public License, or the Artistic License, copies of
+which should have accompanied your Perl kit.
+
+=cut
+

--- a/sift/files/windows-forensic-analysis/JumpList.pm
+++ b/sift/files/windows-forensic-analysis/JumpList.pm
@@ -1,0 +1,514 @@
+package JumpList;
+#---------------------------------------------------------------------
+# JumpList - module to parse Windows 7 Jump Lists, on a binary level
+#
+# Windows 7 Jump Lists (*.automaticDestinations-ms) are based on the
+# OLE/Compound document format, and the individual numbered streams are
+# based the Shortcut/LNK file format.  There is no public documentation 
+# for the format of the DestList stream (which appears to be used as 
+# an MRU/MFU listing).
+# 
+# The purpose of this module is to parse Jump Lists on a binary level
+# without using any proprietary modules (as of Perl 5.12, the OLE::Storage
+# module appears to be deprecated, or at least contains deprecated code).
+# This module will allow the programmer to parse a single 
+# *.automaticDestinations-ms Jump List file, and return both the DestList
+# and the numbered streams in Perl hashes.  This is intended to allow the 
+# programmer to add a GUI, or create specialized output formats (TLN, XML)
+# as needed.
+# 
+# Change History:
+#   20111229 - updated get_stream() to take a stream name instead of a 
+#              size and start sector; that lookup is now handled internally
+#   20110815 - updated
+#   20110812 - created
+#
+# Reference:
+#   http://msdn.microsoft.com/en-us/library/dd942138(v=prot.13).aspx
+#
+# copyright 2011-2012 Quantum Research Analytics, LLC
+#
+# This code is provided under GPLv3, http://www.gnu.org/copyleft/gpl.html
+#---------------------------------------------------------------------
+use strict;
+use Carp;
+use Exporter;
+
+use vars qw($VERSION @ISA @EXPORT @EXPORT_OK %EXPORT_TAGS);
+
+$VERSION     = 20111230;
+@ISA         = qw(Exporter);
+@EXPORT      = ();
+@EXPORT_OK   = qw(new getDirectoryTable getStream getDestList);
+
+# Global variables
+my $file;
+my @fat_sectors = ();
+my @sat;
+my @ssat;
+my @dir_sectors;
+my %directory_table;
+my @root_entry_list;
+my @root_lookup_table;
+my @ssat_sectors;
+my %destlist;
+
+
+END {
+	undef $file;
+	undef @fat_sectors;
+	undef @sat;
+	undef @ssat;
+	undef @dir_sectors;
+	undef %directory_table;
+	undef @root_entry_list;
+	undef @root_lookup_table;
+	undef @ssat_sectors;
+	undef %destlist;
+}
+
+# self reference
+my $self = {};			
+
+#---------------------------------------------------------------------
+# new()
+# 
+#---------------------------------------------------------------------      	    
+sub new {
+	my $class = shift;
+	$file = shift;
+	
+  @fat_sectors        = ();
+	@sat                = ();
+	@ssat               = ();
+	@dir_sectors        = ();
+	%directory_table    = {};
+	@root_entry_list    = ();
+	@root_lookup_table  = ();
+	@ssat_sectors       = ();
+	%destlist           = {};
+	
+	if (-e $file && -f $file) {
+		my @v = get_headers($file);
+		if ($v[0] == 0xe011cfd0 && $v[1] == 0xe11ab1a1) {
+			_init();
+			return bless($self, $class);
+		}
+		else {
+			warn("Incorrect file signature.");
+			return;
+		}
+	}
+	else {
+		warn("File not found.");
+		return;
+	}
+}
+
+#---------------------------------------------------------------------
+# get_headers()
+# 
+# called by new()
+#---------------------------------------------------------------------  
+sub get_headers {
+	my $file = shift;
+	my $data;
+	open(FH,"<",$file) || warn "Could not open file: $!\n";
+	binmode(FH);
+
+	seek(FH,0,0);
+	read(FH,$data,512);
+	close(FH);
+	my $d = substr($data,0,80);
+	my @vals = unpack("VVx16v5x6V10",$d);
+
+#	printf "Header Signature: 0x%08x 0x%08x\n",$vals[0],$vals[1];
+#	printf "Minor Version   : 0x%08x\n",$vals[2];
+#	printf "Major Version   : 0x%08x\n",$vals[3];
+#	printf "Byte Order      : 0x%08x\n",$vals[4];
+#	printf "Sector Shift    : 0x%08x\n",$vals[5];
+#	printf "Mini Sec Shift  : 0x%08x\n",$vals[6];
+#	print  "Num Dir Sectors : $vals[7]\n";
+#	print  "Num FAT Sectors : $vals[8]\n";
+#	printf "1st Dir Loc     : 0x%08x\n",$vals[9];
+#	print  "Tx Sig Number   : $vals[10]\n";
+#	printf "Mini FAT Start  : 0x%08x\n",$vals[12];
+#	print  "# Mini FAT Sect : $vals[13]\n";
+#	printf "First DIFAT Sect: 0x%08x\n",$vals[14];
+#	print  "# DIFAT Sect    : $vals[15]\n";
+#	print "\n";
+
+# @fat_sectors is actually the Master Sector Allocation Table	
+	push(@fat_sectors,0x00);
+ 	
+# if the number of FAT sectors is > 1, we need to populate the list
+# of sectors used	
+	if ($vals[8] > 1) {
+		my @f = unpack("V*",substr($data,0x50,4 * ($vals[8] - 1)));
+		push(@fat_sectors,@f);
+	}
+	
+	return ($vals[0],$vals[1]);
+}
+
+#---------------------------------------------------------------------
+# _init()
+# 
+# called by new()
+#--------------------------------------------------------------------- 
+sub _init {
+#	my $class = shift;
+	get_sat();
+	
+	@dir_sectors = get_lookup_array(1);
+	
+	parse_directory_table();
+	
+	@root_entry_list = get_lookup_array($directory_table{"Root Entry"}{start_sector});
+	
+	get_root_lookup_table();
+	delete $directory_table{"Root Entry"};
+	
+	@ssat_sectors = get_lookup_array(2);
+	
+	get_ssat_array();
+}
+
+#---------------------------------------------------------------------
+# getDirectoryTable()
+# 
+# Returns %directory_table
+#---------------------------------------------------------------------  
+sub getDirectoryTable {
+	my $class = shift;
+	return %directory_table;
+}
+
+#---------------------------------------------------------------------
+# getDestList()
+# 
+# Input: Nothing required (values pulled from %directory_table)
+# Returns hash of hashes containing DestList stream contents
+#---------------------------------------------------------------------
+sub getDestList {
+	my $class = shift;
+	my $stream = get_stream("DestList");
+	return parse_destlist_stream($stream);
+}	
+
+#---------------------------------------------------------------------
+# getStream()
+# 
+# calls internal get_stream() function; 
+# Input: Name of stream (from directory table); not for use with the
+#        DestList stream; that's handled separately
+# Output: binary stream 
+#---------------------------------------------------------------------
+sub getStream {
+	my $class = shift;
+	return get_stream(shift);
+}
+#---------------------------------------------------------------------
+# getSAT()
+# 
+#---------------------------------------------------------------------  
+sub get_sat {
+	my $buffer;
+	my $data;
+	
+	open(FH,"<",$file);
+	binmode(FH);
+	foreach (0..(scalar(@fat_sectors) - 1)) {
+		seek(FH,($fat_sectors[$_] + 1) * 512,0);
+		read(FH,$data,512);
+		$buffer .= $data;
+	}
+	close(FH);
+	undef @fat_sectors;
+	@sat = read_sat($buffer);
+}
+
+#---------------------------------------------------------------------
+# get_lookup_array()
+#  - uses @sat
+#---------------------------------------------------------------------  
+sub get_lookup_array {
+	my $indx = shift;
+	my @list = ();
+	my $tag = 1;
+	
+	while($tag) {
+		if ($sat[$indx] == -2) {
+			push(@list,$indx);
+			$tag = 0;
+		}
+		else {
+			push(@list,$indx);
+			$indx = $sat[$indx];
+		}
+	}
+	return @list;
+}
+
+#---------------------------------------------------------------------
+# parse_directory_table()
+# 
+#--------------------------------------------------------------------- 
+sub parse_directory_table {
+	my $stream;
+	my $buffer;
+	open(FH,"<",$file);
+	binmode(FH);
+	foreach (@dir_sectors) {
+		seek(FH,($_ + 1) * 512,0);
+		read(FH,$buffer,512);
+		$stream .= $buffer;
+	}
+	
+	my $size = 128;
+	my $num = ((length($stream))/$size) - 1;
+	
+	my %entry;
+	foreach my $i (0..$num) {
+		my $data = substr($stream,$i * $size,$size);
+		my $name = substr($data,0,64);
+		$name =~ s/\00//g;
+		next if ($name eq "");
+		$entry{$name}{type} = unpack("c",substr($data,66,1));
+		$entry{$name}{color} = unpack("c",substr($data,67,1));
+		$entry{$name}{leftsibling} = unpack("V",substr($data,68,4));
+#		printf "  Left Sibling : 0x%x\n",$entry{leftsibling};
+		$entry{$name}{rightsibling} = unpack("V",substr($data,72,4));
+#		printf "  Right Sibling: 0x%x\n",$entry{leftsibling};
+		$entry{$name}{childid} = unpack("V",substr($data,76,4));
+#		printf "  Child ID     : 0x%x\n",$entry{childid};
+		$entry{$name}{state}   = unpack("V",substr($data,96,4));
+		
+		my ($c1,$c2) = unpack("VV",substr($data,100,8));
+		$entry{$name}{creation} = getTime($c1,$c2) if ($c1 != 0 && $c2 != 0);
+		my ($m1,$m2) = unpack("VV",substr($data,108,8));
+		$entry{$name}{modification} = getTime($m1,$m2) if ($m1 != 0 && $m2 != 0);
+		
+		$entry{$name}{start_sector} = unpack("V",substr($data,116,4));
+		
+		my ($s1,$s2)  = unpack("VV",substr($data,120,8));
+		$entry{$name}{size} = $s1 if ($s2 == 0);
+	}
+	%directory_table = %entry;
+}
+
+#---------------------------------------------------------------------
+# read_sat()
+# return a sector address table; used by get_sat()
+#--------------------------------------------------------------------- 
+sub read_sat {
+	my $data = shift;
+	
+	my @list = ();
+	my $tag = 1;
+	my $count = 0;
+
+	my @t = unpack("l*",$data);
+	while ($tag) {
+		$list[$count] = $t[$count];
+		$tag = 0 if ($t[$count] == -1);
+# The following line is kind of a hack; sometimes, the SAT doesn't end
+# with a "-1" entry, but it's the last one listed in the final SAT sector.
+# This may happen if the application has a file open, or the system is 
+# acquired live.  In short, once you've gone through the entire SAT, if
+# you haven't reached a -1/0xffffffff, stop.		
+		$tag = 0 if ($count == (length($data)/4));
+		$count++;
+	}
+	return @list;
+}
+
+#---------------------------------------------------------------------
+# get_root_lookup_table()
+#
+# This is probably some of the THE most important code in the module;
+# this code allows the streams to be reassembled from the SSAT (streams
+# smaller than 4096 bytes).
+#---------------------------------------------------------------------
+sub get_root_lookup_table {
+	my $i = 0;
+	foreach my $r (0..(scalar(@root_entry_list) - 1)) {
+		foreach my $t (0..7) {
+			$root_lookup_table[$i] = (($root_entry_list[$r] + 1) * 512) + ($t * 64);
+			$i++;
+		}
+	}	
+}
+
+#---------------------------------------------------------------------
+# get_ssat_array()
+# 
+#---------------------------------------------------------------------
+sub get_ssat_array {
+	my $stream;
+	my $data;
+	open(FH,"<",$file);
+	binmode(FH);
+	foreach (@ssat_sectors) {
+		seek(FH,($_ + 1) *512,0);
+		read(FH,$data,512);
+		$stream .= $data;
+	}
+	close(FH);
+# Now to populate the @ssat list
+	my $tag = 1;
+	my $count = 0;
+	my @t = unpack("l*",$stream);
+	while($tag) {
+		$ssat[$count] = $t[$count];
+		$tag = 0 if ($t[$count] == -1);
+		$count++;
+	}
+# At this point, the @ssat list should be populated
+}
+
+#---------------------------------------------------------------------
+# get_stream()
+# 
+# Internal function; given a stream name (all stream names within a
+# Jump List file appear to be unique), it looks up the stream start_sector
+# and size in the directory table, and returns the binary stream
+#---------------------------------------------------------------------
+sub get_stream {
+	my $name = shift;
+	my $indx = $directory_table{$name}{start_sector};
+	my $size = $directory_table{$name}{size};
+	my $str;
+	my $data;
+	
+# Where you go to assemble the stream depends on the size;
+# 4096 bytes or more, and the stream is found in the SAT,
+# otherwise it's in the SSAT (sectors = 64 bytes)
+	if ($size >= 4096) {
+		my @list = get_lookup_array($indx);
+		open(FH,"<",$file);
+		binmode(FH);
+		foreach my $i (0..(scalar(@list) - 1)) {
+			seek(FH,($list[$i] + 1) * 512,0);
+			read(FH,$data,512);
+			$str .= $data;
+		}
+		close(FH);
+	}
+	else {
+		my @list = get_stream_sector_array($indx);
+		open(FH,"<",$file);
+		binmode(FH);
+		foreach my $i (0..(scalar(@list) - 1)) {
+			seek(FH,$root_lookup_table[$list[$i]],0);
+			read(FH,$data,64);
+			$str .= $data;
+		}
+		close(FH);
+	}
+	
+	return substr($str,0,$size);
+}
+
+#---------------------------------------------------------------------
+# get_stream_sector_array()
+# 
+#---------------------------------------------------------------------
+sub get_stream_sector_array {
+	my $indx = shift;
+	my @list = ();
+	my $tag = 1;
+	while($tag) {
+		push(@list,$indx);
+		($ssat[$indx] == -2)?($tag = 0):($indx = $ssat[$indx]);
+	}
+	return @list;
+}
+
+#---------------------------------------------------------------------
+# parse_destlist_stream()
+# 
+# Parses the DestList stream; populates the %destlist hash-of-hashes
+# Key: position
+#         mrutime - FILETIME
+#         str     - string
+#         uname   - system name
+#---------------------------------------------------------------------
+sub parse_destlist_stream {
+	my $stream = shift;
+	my %destlist;
+	my @num = unpack("VV",substr($stream,4,8));
+	my @num2 = unpack("VV",substr($stream,24,8));
+#if ($num[1] == 0) {
+#	print "Number of entries = ".$num[0]."\n";
+#}
+#print "Valid header.\n" if ($num2[0] == $num[0] && $num2[1] == $num[1]);
+
+# Start reading the first "object" or structure
+	my $offset = 0x20;
+	foreach (1..$num[0]) {
+		my $str_sz = unpack("v",substr($stream,$offset + 112,2));
+
+# Total structure size = 112 + 2 + ($str_sz * 2) bytes
+		my $sz = 112 + 2 + ($str_sz * 2);
+		my $data = substr($stream, $offset, $sz);
+		my %st = parse_destlist_struct($data);
+		
+		$destlist{$st{position}}{mrutime} = $st{mrutime};
+		$destlist{$st{position}}{str}     = $st{str};
+		$destlist{$st{position}}{uname}   = $st{uname};
+		$offset += $sz;
+	}
+	return %destlist;
+}
+
+#---------------------------------------------------------------------
+# parse_destlist_struct()
+# 
+# Parses individual DestList stream structures
+#---------------------------------------------------------------------
+sub parse_destlist_struct {
+	my $data = shift;
+	my %struct;
+	
+#	$struct{t1} = getTime(unpack("VV",substr($data,24,8))); 
+#	$struct{t2} = getTime(unpack("VV",substr($data,56,8)));
+	my @t = unpack("VV",substr($data,100,8));
+	$struct{mrutime} = getTime($t[0],$t[1]);
+	$struct{uname} = substr($data,72,16);
+	$struct{uname} =~ s/\00//g;
+	
+	my @mark = unpack("VV",substr($data,88,8));
+	if ($mark[1] == 0) {
+		$struct{position} = sprintf "%x",$mark[0];
+	}
+	
+	my $sz = unpack("v",substr($data,112,2));
+	$struct{str} = substr($data,114,($sz * 2));
+	$struct{str} =~ s/\00//g;
+	return %struct;
+}
+
+#-------------------------------------------------------------
+# getTime()
+# Translate FILETIME object (2 DWORDS) to Unix time, to be passed
+# to gmtime() or localtime()
+#
+# The code was borrowed from Andreas Schuster's excellent work
+#-------------------------------------------------------------
+sub getTime($$) {
+	my $lo = shift;
+	my $hi = shift;
+	my $t;
+
+	if ($lo == 0 && $hi == 0) {
+		$t = 0;
+	} else {
+		$lo -= 0xd53e8000;
+		$hi -= 0x019db1de;
+		$t = int($hi*429.4967296 + $lo/1e7);
+	};
+	$t = 0 if ($t < 0);
+	return $t;
+}
+1;

--- a/sift/files/windows-forensic-analysis/LNK.pm
+++ b/sift/files/windows-forensic-analysis/LNK.pm
@@ -1,0 +1,1092 @@
+package LNK;
+#---------------------------------------------------------------------
+# LNK - module to parse Windows shortcut/LNK files, on a binary level
+#
+#	Based on MS documentation available here (MS-SHLLLNK binary format):
+#  http://msdn.microsoft.com/en-us/library/dd871305%28v=prot.13%29.aspx
+#
+#
+# Returns hash with the following keys (if found):
+#	  atime, ctime, mtime, filesize
+#   volumename, volume_sn, volume_type
+#   basepath
+#	  description, relativepath, workingdir, commandline (if found)
+# 
+# Change History:
+#   20130103 - began updating the include parsing SHITEMIDLIST
+#   20111228 - added code to remove trailing \00 from nul-term strings
+#   20111227 - added parsing of UUID v1 structures, based in part on 
+#              UUID::Tiny
+#   20111226 - added parsing of CommonNetworkRelativeLink, etc.
+#   20110823 - modified reporting of LNK Basename to include cli, if avail.
+#   20110815 - created
+#
+# To-do: 
+#   Add parsing of network volume information
+#
+# copyright 2011-2012 Quantum Research Analytics, LLC
+#
+# This code is provided under GPLv3, http://www.gnu.org/copyleft/gpl.html
+#---------------------------------------------------------------------
+use strict;
+use Carp;
+use Exporter;
+use Time::Local;
+
+use vars qw($VERSION @ISA @EXPORT @EXPORT_OK %EXPORT_TAGS);
+
+$VERSION     = 20130103;
+@ISA         = qw(Exporter);
+@EXPORT      = ();
+@EXPORT_OK   = qw(new getLNK);
+
+# Global variables
+my $stream;
+# %lnk is a global structure that gets populated by various
+# functions within the module
+my %lnk;
+# self reference
+my $self = {};			
+
+
+my %cp_guids = ("{bb64f8a7-bee7-4e1a-ab8d-7d8273f7fdb6}" => "Action Center",
+    "{7a979262-40ce-46ff-aeee-7884ac3b6136}" => "Add Hardware",
+    "{d20ea4e1-3957-11d2-a40b-0c5020524153}" => "Administrative Tools",
+    "{9c60de1e-e5fc-40f4-a487-460851a8d915}" => "AutoPlay",
+    "{b98a2bea-7d42-4558-8bd1-832f41bac6fd}" => "Backup and Restore Center",
+    "{0142e4d0-fb7a-11dc-ba4a-000ffe7ab428}" => "Biometric Devices",
+    "{d9ef8727-cac2-4e60-809e-86f80a666c91}" => "BitLocker Drive Encryption",
+    "{b2c761c6-29bc-4f19-9251-e6195265baf1}" => "Color Management",
+    "{1206f5f1-0569-412c-8fec-3204630dfb70}" => "Credential Manager",
+    "{e2e7934b-dce5-43c4-9576-7fe4f75e7480}" => "Date and Time",
+    "{00c6d95f-329c-409a-81d7-c46c66ea7f33}" => "Default Location",
+    "{17cd9488-1228-4b2f-88ce-4298e93e0966}" => "Default Programs",
+    "{37efd44d-ef8d-41b1-940d-96973a50e9e0}" => "Desktop Gadgets",
+    "{74246bfc-4c96-11d0-abef-0020af6b0b7a}" => "Device Manager",
+    "{a8a91a66-3a7d-4424-8d24-04e180695c7a}" => "Devices and Printers",
+    "{c555438b-3c23-4769-a71f-b6d3d9b6053a}" => "Display",
+    "{d555645e-d4f8-4c29-a827-d93c859c4f2a}" => "Ease of Access Center",
+    "{6dfd7c5c-2451-11d3-a299-00c04f8ef6af}" => "Folder Options",
+    "{93412589-74d4-4e4e-ad0e-e0cb621440fd}" => "Fonts",
+    "{259ef4b1-e6c9-4176-b574-481532c9bce8}" => "Game Controllers",
+    "{15eae92e-f17a-4431-9f28-805e482dafd4}" => "Get Programs",
+    "{cb1b7f8c-c50a-4176-b604-9e24dee8d4d1}" => "Getting Started",
+    "{67ca7650-96e6-4fdd-bb43-a8e774f73a57}" => "HomeGroup",
+    "{87d66a43-7b11-4a28-9811-c86ee395acf7}" => "Indexing Options",
+    "{a0275511-0e86-4eca-97c2-ecd8f1221d08}" => "Infrared",
+    "{a3dd4f92-658a-410f-84fd-6fbbbef2fffe}" => "Internet Options",
+    "{a304259d-52b8-4526-8b1a-a1d6cecc8243}" => "iSCSI Initiator",
+    "{725be8f7-668e-4c7b-8f90-46bdb0936430}" => "Keyboard",
+    "{e9950154-c418-419e-a90a-20c5287ae24b}" => "Location and Other Sensors",
+    "{1fa9085f-25a2-489b-85d4-86326eedcd87}" => "Manage Wireless Networks",
+    "{6c8eec18-8d75-41b2-a177-8831d59d2d50}" => "Mouse",
+    "{7007acc7-3202-11d1-aad2-00805fc1270e}" => "Network Connections",
+    "{8e908fc9-becc-40f6-915b-f4ca0e70d03d}" => "Network and Sharing Center",
+    "{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}" => "Notification Area Icons",
+    "{d24f75aa-4f2b-4d07-a3c4-469b3d9030c4}" => "Offline Files",
+    "{96ae8d84-a250-4520-95a5-a47a7e3c548b}" => "Parental Controls",
+    "{f82df8f7-8b9f-442e-a48c-818ea735ff9b}" => "Pen and Input Devices",
+    "{5224f545-a443-4859-ba23-7b5a95bdc8ef}" => "People Near Me",
+    "{78f3955e-3b90-4184-bd14-5397c15f1efc}" => "Performance Information and Tools",
+    "{ed834ed6-4b5a-4bfe-8f11-a626dcb6a921}" => "Personalization",
+    "{40419485-c444-4567-851a-2dd7bfa1684d}" => "Phone and Modem",
+    "{025a5937-a6be-4686-a844-36fe4bec8b6d}" => "Power Options",
+    "{2227a280-3aea-1069-a2de-08002b30309d}" => "Printers",
+    "{fcfeecae-ee1b-4849-ae50-685dcf7717ec}" => "Problem Reports and Solutions",
+    "{7b81be6a-ce2b-4676-a29e-eb907a5126c5}" => "Programs and Features",
+    "{9fe63afd-59cf-4419-9775-abcc3849f861}" => "Recovery",
+    "{62d8ed13-c9d0-4ce8-a914-47dd628fb1b0}" => "Regional and Language Options",
+    "{241d7c96-f8bf-4f85-b01f-e2b043341a4b}" => "RemoteApp and Desktop Connections",
+    "{00f2886f-cd64-4fc9-8ec5-30ef6cdbe8c3}" => "Scanners and Cameras",
+    "{f2ddfc82-8f12-4cdd-b7dc-d4fe1425aa4d}" => "Sound",
+    "{58e3c745-d971-4081-9034-86e34b30836a}" => "Speech Recognition Options",
+    "{9c73f5e5-7ae7-4e32-a8e8-8d23b85255bf}" => "Sync Center",
+    "{bb06c0e4-d293-4f75-8a90-cb05b6477eee}" => "System",
+    "{80f3f1d5-feca-45f3-bc32-752c152e456e}" => "Tablet PC Settings",
+    "{0df44eaa-ff21-4412-828e-260a8728e7f1}" => "Taskbar and Start Menu",
+    "{d17d1d6d-cc3f-4815-8fe3-607e7d5d10b3}" => "Text to Speech",
+    "{c58c4893-3be0-4b45-abb5-a63e4b8c8651}" => "Troubleshooting",
+    "{60632754-c523-4b62-b45c-4172da012619}" => "User Accounts",
+    "{be122a0e-4503-11da-8bde-f66bad1e3f3a}" => "Windows Anytime Upgrade",
+    "{78cb147a-98ea-4aa6-b0df-c8681f69341c}" => "Windows CardSpace",
+    "{d8559eb9-20c0-410e-beda-7ed416aecc2a}" => "Windows Defender",
+    "{4026492f-2f69-46b8-b9bf-5654fc07e423}" => "Windows Firewall",
+    "{3e7efb4c-faf1-453d-89eb-56026875ef90}" => "Windows Marketplace",
+    "{5ea4f148-308c-46d7-98a9-49041b1dd468}" => "Windows Mobility Center",
+    "{087da31b-0dd3-4537-8e23-64a18591f88b}" => "Windows Security Center",
+    "{e95a4861-d57a-4be1-ad0f-35267e261739}" => "Windows SideShow",
+    "{36eef7db-88ad-4e81-ad49-0e313f0c35f8}" => "Windows Update");
+    
+my %folder_types = ("{724ef170-a42d-4fef-9f26-b60e846fba4f}" => "Administrative Tools",
+    "{d0384e7d-bac3-4797-8f14-cba229b392b5}" => "Common Administrative Tools",
+    "{de974d24-d9c6-4d3e-bf91-f4455120b917}" => "Common Files",
+    "{c1bae2d0-10df-4334-bedd-7aa20b227a9d}" => "Common OEM Links",
+    "{5399e694-6ce5-4d6c-8fce-1d8870fdcba0}" => "Control Panel",
+    "{1ac14e77-02e7-4e5d-b744-2eb1ae5198b7}" => "CSIDL_SYSTEM",
+    "{b4bfcc3a-db2c-424c-b029-7fe99a87c641}" => "Desktop",
+    "{7b0db17d-9cd2-4a93-9733-46cc89022e7c}" => "Documents Library",
+    "{fdd39ad0-238f-46af-adb4-6c85480369c7}" => "Documents",
+    "{374de290-123f-4565-9164-39c4925e467b}" => "Downloads",
+    "{de61d971-5ebc-4f02-a3a9-6c82895e5c04}" => "Get Programs",
+    "{a305ce99-f527-492b-8b1a-7e76fa98d6e4}" => "Installed Updates",
+    "{871c5380-42a0-1069-a2ea-08002b30309d}" => "Internet Explorer (Homepage)",
+    "{031e4825-7b94-4dc3-b131-e946b44c8dd5}" => "Libraries",
+    "{4bd8d571-6d19-48d3-be97-422220080e43}" => "Music",
+    "{20d04fe0-3aea-1069-a2d8-08002b30309d}" => "My Computer",
+    "{450d8fba-ad25-11d0-98a8-0800361b1103}" => "My Documents",
+    "{ed228fdf-9ea8-4870-83b1-96b02cfe0d52}" => "My Games",
+    "{208d2c60-3aea-1069-a2d7-08002b30309d}" => "My Network Places",
+    "{f02c1a0d-be21-4350-88b0-7367fc96ef3c}" => "Network", 
+    "{33e28130-4e1e-4676-835a-98395c3bc3bb}" => "Pictures",
+    "{a990ae9f-a03b-4e80-94bc-9912d7504104}" => "Pictures",
+    "{7c5a40ef-a0fb-4bfc-874a-c0f2e0b9fa8e}" => "Program Files (x86)",
+    "{905e63b6-c1bf-494e-b29c-65b732d3d21a}" => "Program Files",
+    "{df7266ac-9274-4867-8d55-3bd661de872d}" => "Programs and Features",
+    "{3214fab5-9757-4298-bb61-92a9deaa44ff}" => "Public Music",
+    "{b6ebfb86-6907-413c-9af7-4fc2abf07cc5}" => "Public Pictures",
+    "{2400183a-6185-49fb-a2d8-4a392a602ba3}" => "Public Videos",
+    "{4336a54d-38b-4685-ab02-99bb52d3fb8b}"  => "Public",
+    "{491e922f-5643-4af4-a7eb-4e7a138d8174}" => "Public",
+    "{dfdf76a2-c82a-4d63-906a-5644ac457385}" => "Public",
+    "{645ff040-5081-101b-9f08-00aa002f954e}" => "Recycle Bin",
+    "{d65231b0-b2f1-4857-a4ce-a8e7c6ea7d27}" => "System32 (x86)",
+    "{9e52ab10-f80d-49df-acb8-4330f5687855}" => "Temporary Burn Folder",
+    "{f3ce0f7c-4901-4acc-8648-d5d44b04ef8f}" => "Users Files",
+    "{59031a47-3f72-44a7-89c5-5595fe6b30ee}" => "Users",
+    "{f38bf404-1d43-42f2-9305-67de0b28fc23}" => "Windows");
+
+#---------------------------------------------------------------------
+# new()
+# 
+#---------------------------------------------------------------------      	    
+sub new {
+	my $class = shift;
+	%lnk = {};
+	$stream;
+	return bless($self, $class);
+}
+
+#---------------------------------------------------------------------
+# file()
+# 
+#--------------------------------------------------------------------- 
+sub getLNK {
+	my $class = shift;
+	my $file = shift;
+	
+	if (-e $file && -f $file) {
+		my $sz = (stat($file))[7];
+		
+		open(FH,"<",$file) || warn "Could not open file: $!";
+		binmode(FH);
+		seek(FH,0,0);
+		read(FH,$stream,$sz);
+		close(FH);
+		if (unpack("V",substr($stream,0,4)) == 0x4C) {
+			parseLNK();
+			return %lnk;
+		}
+		else {
+			return;
+		}
+	}
+	elsif (unpack("V",substr($file,0,4)) == 0x4C) {
+		$stream = $file;
+		parseLNK();
+		return %lnk;
+	}
+	else {
+		return;
+	}
+}
+
+#---------------------------------------------------------------------
+# parseLNK()
+# 
+#--------------------------------------------------------------------- 
+sub parseLNK {
+# start with the header
+	my $offset = 0;
+	my $data = substr($stream,$offset,0x4C);
+	
+	my %hdr;
+	($hdr{id},$hdr{flags},$hdr{attr},$hdr{ctime_0},$hdr{ctime_1},
+	 $hdr{atime_0},$hdr{atime_1},$hdr{mtime_0},$hdr{mtime_1},
+	 $hdr{filesize},$hdr{icon_num},$hdr{showwnd},$hdr{hotkey}) = unpack("Vx16V12x8",$data);
+	
+	undef $hdr{filesize} if ($hdr{filesize} == 0);
+	 
+# MAC times for target file
+	$lnk{mtime} = getTime(($hdr{mtime_0},$hdr{mtime_1})) if ($hdr{mtime_0} != 0 && $hdr{mtime_0} != 1);
+	$lnk{atime} = getTime(($hdr{atime_0},$hdr{atime_1})) if ($hdr{atime_0} != 0 && $hdr{atime_0} != 1);
+	$lnk{ctime} = getTime(($hdr{ctime_0},$hdr{ctime_1})) if ($hdr{ctime_0} != 0 && $hdr{ctime_0} != 1);
+	$lnk{filesize} = $hdr{filesize};
+	$offset += 0x4C;
+
+# Check for TargetIDList/ItemIDList; skip if there is one
+	if ($hdr{flags} & 0x01) {
+		my $len = unpack("v",substr($stream,$offset,2));
+		my $str = parseIDList(substr($stream,$offset,$len));
+		$lnk{shitemidlist} = $str;
+		$offset += (2 + $len);
+	}
+	
+# Get LinkInfo structure
+	if ($hdr{flags} & 0x02) {
+# If a LinkInfo structure exists, get the size of the structure,
+# then send the stream to parseLNKInfo() to be parsed.
+		my $li_size = unpack("V",substr($stream,$offset,4));
+#		print "  Size: ".$li_size."\n";
+		parseLNKInfo(substr($stream,$offset,$li_size));
+# Move the cursor the entire length of the LinkInfo structure
+		$offset += $li_size;
+	}
+	else {
+#		print "No LinkInfo block.\n";
+	}
+	
+# Check for Name/Description string		
+	if ($hdr{flags} & 0x04) {
+		my ($desc,$len) = getUnicodeString($offset);
+		$lnk{description} = $desc;
+		$offset += $len;
+	}
+# Check for relative path string		
+	if ($hdr{flags} & 0x08) {
+		my ($rel,$tot) = getUnicodeString($offset);
+		$lnk{relativepath} = $rel;
+		$offset += $tot;
+	}
+# Check for working directory
+	if ($hdr{flags} & 0x10) {
+		my ($cwd,$tot) = getUnicodeString($offset);
+		$lnk{workingdir} = $cwd;
+		$offset += $tot;
+	}
+# Command Line string		
+	if ($hdr{flags} & 0x20) {
+		my ($cli,$tot) = getUnicodeString($offset);
+#remove leading spaces		
+		$cli =~ s/^\s+//g;
+		$lnk{commandline} = $cli;
+#    $lnk{basename} .= $cli;
+		$offset += $tot;
+	}
+# Icon file		
+	if ($hdr{flags} & 0x40) {
+		my ($ico,$tot) = getUnicodeString($offset);
+		$lnk{iconfilename} = $ico;
+#			print "    Icon Filename : ".$ico."\n";
+		$offset += $tot;
+	}
+
+# Process ExtraData blocks, looking for TrackerData Block		
+	my $tag = 1;
+	while($tag) {
+		my $sz = unpack("V",substr($stream,$offset,4));
+		if ($sz == 0) {
+			$tag = 0;
+		}
+		else {
+			my $id = unpack("V",substr($stream,$offset + 4,4));
+#			printf "Size: $sz, ID: 0x%x\n",$id;			
+			if ($id == 0xa0000003) {
+				my $track = substr($stream,$offset,$sz);
+				getTrackerData($track);
+			}
+		}
+		$offset += $sz;
+	}
+}
+
+#-----------------------------------------------------------
+# parseLNKInfo()
+#
+# Parse the LinkInfo structure, based on section 2.3 of 
+# the reference
+#-----------------------------------------------------------
+sub parseLNKInfo {
+  my $li_stream = shift;
+	my $ofs = 0;
+	my %li;
+	my ($size,$hdr) = unpack("VV",substr($li_stream,$ofs,8));
+	if ($hdr == 0x1c) {
+		($li{size},$li{hdrsize},$li{flags},$li{volidofs},$li{lbpofs},
+		 $li{cnrlofs},$li{cpsofs}) = unpack("V7",substr($li_stream,$ofs,0x1c));
+	}
+	elsif ($hdr == 0x24) {
+		($li{size},$li{hdrsize},$li{flags},$li{volidofs},$li{lbpofs},
+		 $li{cnrlofs},$li{cpsofs},$li{lbpofsu},$li{cpsofsu}) 
+		 = unpack("V9",substr($li_stream,$ofs,0x1c));
+	}
+	
+	if ($li{flags} & 0x01) {
+		my $vol_sz = unpack("V",substr($li_stream,$ofs + $li{volidofs},4));
+		volIDTable(substr($li_stream,$ofs + $li{volidofs},$vol_sz));
+# Get the Local Base Path; populate $lnk{basepath}
+		my $tag = 1;
+		my $ctr = 0;
+		while ($tag) {
+			my $ch = substr($li_stream,$li{lbpofs} + $ctr,1);
+			$tag = 0 if (unpack("c",$ch) < 0x1F);
+			$lnk{basepath} .= $ch;
+			$ctr++;
+		}
+		$lnk{basepath} =~ s/\00//g;
+	}
+	
+	if ($li{flags} & 0x02) {
+# The structure has a CommonNetworkRelativeLink		
+	  my $c_sz = unpack("V",substr($li_stream,$ofs + $li{cnrlofs},4));	
+		getCommonNetworkRelativeLink(substr($li_stream,$ofs + $li{cnrlofs},$c_sz));
+	}
+	
+	if ($li{cpsofs}) {
+#Get the CommonPathSuffix
+		my $tag = 1;
+		my $ctr = 0;
+		while ($tag) {
+			my $ch = substr($li_stream,$li{cpsofs} + $ctr,1);
+			$tag = 0 if (unpack("c",$ch) < 0x1F);
+			$lnk{commonpathsuffix} .= $ch;
+			$ctr++;
+		}
+		$lnk{commonpathsuffix} =~ s/\00//g;
+	}
+}
+ 
+#-----------------------------------------------------------
+#
+#
+#-----------------------------------------------------------
+sub volIDTable {
+	my $vol_stream = shift;
+	my %lv;
+	my %types = (0 => "Unknown",
+	             1 => "No root dir",
+	             2 => "Removable",
+	             3 => "Fixed Disk",
+	             4 => "Remote",
+	             5 => "CD-ROM",
+	             6 => "RAM Drive");
+	             
+#	($lv{len},$lv{type},$lv{vol_sn},$lv{ofs}) = unpack("V4",substr($vol_stream,0,0x10));
+	($lv{len},$lv{type},$lv{ofs}) = unpack("V2x4V",substr($vol_stream,0,0x10));
+	$lnk{vol_type} = $types{$lv{type}};
+	
+# Need to see about reworking the following	
+	my @sn = unpack("vv",substr($vol_stream,8,4));
+	$lnk{vol_sn} = uc(sprintf "%04x-%04x",$sn[1],$sn[0]);
+	
+	if ($lv{ofs} > 0 && !($lv{ofs} == 0x14)) {
+		my $cnt = 0;
+		my $tag = 1;
+		while ($tag) {
+			my $char = substr($vol_stream,(0 + $lv{ofs} + $cnt),1);
+			if (unpack("c",$char) == 0x0) {
+				$tag = 0;
+			}
+			else {
+				$lnk{vol_name} .= $char;
+				$cnt++;
+			}
+		}
+	}	
+	else {
+# in this case, the value of the VolumeLabelOffset == 0x14,
+# so the VolumeLabelOffsetUnicode must be used
+		$lv{ofs_u} = unpack("V",substr($vol_stream,0x10,4));		
+	}
+}
+
+#-----------------------------------------------------------
+#
+#
+#-----------------------------------------------------------
+sub getCommonNetworkRelativeLink {
+  my $c_stream = shift;
+  my $ofs = 0;
+  my %rl;
+  ($rl{size},$rl{flags},$rl{netnameofs},$rl{devnameofs},$rl{netprovtype}) 
+  = unpack("V5",substr($c_stream,$ofs,20));
+	
+	if ($rl{flags} & 0x01) {
+		my $tag = 1;
+		my $ctr = 0;
+		while ($tag) {
+			my $ch = substr($c_stream,$rl{devnameofs} + $ctr,1);
+			$tag = 0 if (unpack("c",$ch) < 0x1F);
+			$lnk{devname} .= $ch;
+			$ctr++;
+		}
+		$lnk{devname} =~ s/\00//g;
+	}
+	
+  if ($rl{flags} & 0x02) {
+  	my $tag = 1;
+		my $ctr = 0;
+		while ($tag) {
+			my $ch = substr($c_stream,$rl{netnameofs} + $ctr,1);
+			$tag = 0 if (unpack("c",$ch) < 0x1F);
+			$lnk{netname} .= $ch;
+			$ctr++;
+		}
+		$lnk{netname} =~ s/\00//g;
+  }
+}
+
+#-----------------------------------------------------------
+# getTrackerData()
+# Parse the ExtraData structure for a TrackerDataBlock
+#-----------------------------------------------------------
+sub getTrackerData {
+	my $td_stream = shift;
+# get the machine ID	
+	$lnk{machineID} = substr($td_stream,16,16);
+	$lnk{machineID} =~ s/\00//g;
+
+# Decode the "Droids"; each "droid" is a set of 2 GUIDs
+# The first droid is the New Volume ID, object ID	
+	$lnk{new_vol_id} = uc(unpack("H*",substr($td_stream,32,16)));
+	my %t = getObjectIDStruct(substr($td_stream,48,16));
+	$lnk{new_obj_id_time} = $t{time};
+	$lnk{new_obj_id_seq}  = $t{seq};
+	$lnk{new_obj_id_node} = $t{node};
+	
+# Second droid is the birth volume ID, object ID
+	$lnk{birth_vol_id} = uc(unpack("H*",substr($td_stream,64,16)));
+	my %t = getObjectIDStruct(substr($td_stream,80,16));
+	$lnk{birth_obj_id_time} = $t{time};
+	$lnk{birth_obj_id_seq}  = $t{seq};
+	$lnk{birth_obj_id_node} = $t{node};
+}
+
+#-----------------------------------------------------------
+# getUnicodeString()
+#
+# Function to read through various elements of the StringData
+# section of the LNK file; returns the string and the total
+# number of bytes to move the cursor
+#-----------------------------------------------------------
+sub getUnicodeString {
+	my $ofs = shift;
+	my $len = unpack("v",substr($stream,$ofs,2));
+	my $str = substr($stream,$ofs + 2, $len * 2);
+	$str =~ s/\00//g;
+	my $tot = 2 + ($len * 2);
+	return $str,$tot;	
+}
+
+#-------------------------------------------------------------
+# getTime()
+# Translate FILETIME object (2 DWORDS) to Unix time, to be passed
+# to gmtime() or localtime()
+#
+# The code was borrowed from Andreas Schuster's excellent work
+#-------------------------------------------------------------
+sub getTime($$) {
+	my $lo = shift;
+	my $hi = shift;
+	my $t;
+
+	if ($lo == 0 && $hi == 0) {
+		$t = 0;
+	} else {
+		$lo -= 0xd53e8000;
+		$hi -= 0x019db1de;
+		$t = int($hi*429.4967296 + $lo/1e7);
+	};
+	$t = 0 if ($t < 0);
+	return $t;
+}
+
+#-------------------------------------------------------------
+# getObjectIDStruct()
+#
+# Input : 16 byte binary ObjectID stream
+# Output: hash containing v1 UUID structure 
+#-------------------------------------------------------------
+sub getObjectIDStruct($) {
+	my $bstr = shift;
+	my $version = (split(//,unpack("H*",substr($bstr,7,1))))[0];
+	return unless ($version == 1); 
+	my %struct;
+	$struct{version} = $version;
+	
+# Translate 60-bit ObjectID time to Unix time, to be passed
+# to gmtime() or localtime()
+	my $l = unpack("V",substr($bstr,0,4));
+	my $m = unpack("v",substr($bstr,4,2));
+	my $h = unpack("v",substr($bstr,6,2)) & 0x0fff;
+	my $h = $m | $h << 16;
+	$struct{time} = (getTime($l,$h) - 574819200);
+# Get the clock sequence number
+	my $b = unpack("B*",substr($bstr,8,2));
+	my $f = "00".substr($b,2,14);
+	$struct{seq} = unpack("n",pack("B16",$f));
+
+# Get the node; may or may not be the MAC address of the system
+# Not pretty, but I'll take it
+	my @n = split(//,unpack("H*",substr($bstr,10,6)));
+	$struct{node} = $n[0].$n[1].":".$n[2].$n[3].":".$n[4].$n[5].":".$n[6].$n[7].
+	                ":".$n[8].$n[9].":".$n[10].$n[11];
+	return %struct;
+}
+
+#-------------------------------------------------------------
+# parseIDList()
+#
+#-------------------------------------------------------------
+sub parseIDList {
+	my $data = shift;
+	my $len = unpack("v",substr($data,0,2));
+	
+	my $ofs = 2;
+	my %item;
+	
+	my @str;
+	
+	while ($ofs < $len) {
+		my $sz = unpack("v",substr($data,$ofs,2));
+		my $type = unpack("C",substr($data,$ofs + 2,1));
+
+		if ($type == 0x1F) {
+			%item = parseSystemFolderEntry(substr($data,$ofs,$sz));
+		}
+		elsif ($type == 0x00) {
+			%item = parseVariableEntry(substr($data,$ofs,$sz));
+		}
+		elsif ($type == 0x2E) {
+			%item = parseDeviceEntry(substr($data,$ofs,$sz));
+		}
+		elsif ($type == 0x2F) {
+# Volume (Drive Letter) 			
+ 			%item = parseDriveEntry(substr($data,$ofs,$sz));
+ 		}
+ 		elsif ($type == 0xc3 || $type == 0x41 || $type == 0x42 || $type == 0x46 || $type == 0x47) {
+# Network stuff
+			my $id = unpack("C",substr(substr($data,$ofs,$sz),3,1));
+			if ($type == 0xc3 && $id != 0x01) {
+				%item = parseNetworkEntry(substr($data,$ofs,$sz));
+			}
+			else {
+				%item = parseNetworkEntry(substr($data,$ofs,$sz)); 
+			}
+ 		}
+ 		elsif ($type == 0x31 || $type == 0x32 || $type == 0xb1 || $type == 0x74) {
+# Folder or Zip File			
+ 			%item = parseFolderEntry(substr($data,$ofs,$sz)); 
+ 		}
+ 		elsif ($type == 0x35) {
+ 			%item = parseFolderEntry2(substr($data,$ofs,$sz));
+ 		}
+ 		elsif ($type == 0x71) {
+# Control Panel
+			%item = parseControlPanelEntry(substr($data,$ofs,$sz)); 			
+ 		}
+ 		elsif ($type == 0x61) {
+# URI type
+			%item = parseURIEntry(substr($data,$ofs,$sz));		
+ 		}
+		else {
+			$item{name} = sprintf "Type 0x%x",$type;			
+		}
+		push(@str,$item{name});
+		$ofs += $sz;
+	}
+	return join('/',@str);
+}
+
+#-----------------------------------------------------------
+#
+#-----------------------------------------------------------
+sub parseSystemFolderEntry {
+	my $data     = shift;
+	my %item = ();
+	
+	my %vals = (0x00 => "Explorer",
+	            0x42 => "Libraries",
+	            0x44 => "Users",
+	            0x4c => "Public",
+	            0x48 => "My Documents",
+	            0x50 => "My Computer",
+	            0x58 => "My Network Places",
+	            0x60 => "Recycle Bin",
+	            0x68 => "Explorer",
+	            0x70 => "Control Panel",
+	            0x78 => "Recycle Bin",
+	            0x80 => "My Games");
+	
+	$item{type} = unpack("C",substr($data,2,1));
+	$item{id}   = unpack("C",substr($data,3,1));
+	if (exists $vals{$item{id}}) {
+		$item{name} = $vals{$item{id}};
+	}
+	else {
+		$item{name} = parseGUID(substr($data,4,16));
+	}
+	return %item;
+}
+
+#-----------------------------------------------------------
+# parseGUID()
+# Takes 16 bytes of binary data, returns a string formatted
+# as an MS GUID.
+#-----------------------------------------------------------
+sub parseGUID {
+	my $data     = shift;
+  my $d1 = unpack("V",substr($data,0,4));
+  my $d2 = unpack("v",substr($data,4,2));
+  my $d3 = unpack("v",substr($data,6,2));
+	my $d4 = unpack("H*",substr($data,8,2));
+  my $d5 = unpack("H*",substr($data,10,6));
+  return sprintf "{%08x-%x-%x-$d4-$d5}",$d1,$d2,$d3;
+}
+
+#-----------------------------------------------------------
+#
+#-----------------------------------------------------------
+sub parseDeviceEntry {
+	my $data = shift;
+	my %item = ();
+	
+	my $userlen = unpack("V",substr($data,30,4));
+	my $devlen  = unpack("V",substr($data,34,4));
+	
+	my $user    = substr($data,0x28,$userlen * 2);
+	$user =~ s/\00//g;
+	
+	my $dev = substr($data,0x28 + ($userlen * 2),$devlen * 2);
+	$dev =~ s/\00//g;
+	
+	$item{name} = $user;
+	return %item;
+}
+
+#-----------------------------------------------------------
+# parseVariableEntry()
+#
+#-----------------------------------------------------------
+sub parseVariableEntry {
+	my $data     = shift;
+	my %item = ();
+	
+	$item{type} = unpack("C",substr($data,2,1));
+	my $tag = unpack("C",substr($data,0x0A,1));
+	
+	if (unpack("v",substr($data,4,2)) == 0x1A) {
+		my $guid = parseGUID(substr($data,14,16));
+		
+		if (exists $folder_types{$guid}) {
+			$item{name} = $folder_types{$guid};
+		}
+		else {
+			$item{name} = $guid;
+		}
+	}
+	elsif (grep(/1SPS/,$data)) { 
+	  my @seg = split(/1SPS/,$data);  
+	  
+	  my %segs = ();
+	  foreach my $s (0..(scalar(@seg) - 1)) {
+	  	my $guid = parseGUID(substr($seg[$s],0,16));
+	  	$segs{$guid} = $seg[$s];
+	  }
+	  
+	  if (exists $segs{"{b725f130-47ef-101a-a5f1-02608c9eebac}"}) { 
+# Ref: http://msdn.microsoft.com/en-us/library/aa965725(v=vs.85).aspx	  	 	
+	  	my $stuff = $segs{"{b725f130-47ef-101a-a5f1-02608c9eebac}"};
+
+	  	my $tag = 1;
+	  	my $cnt = 0x10;
+	  	while($tag) {
+	  		my $sz = unpack("V",substr($stuff,$cnt,4));
+	  		my $id = unpack("V",substr($stuff,$cnt + 4,4));
+#--------------------------------------------------------------
+# sub-segment types
+# 0x0a - file name
+# 0x14 - short name
+# 0x0e, 0x0f, 0x10 - mod date, create date, access date(?)
+# 0x0c - size
+#--------------------------------------------------------------	  	
+	  		if ($sz == 0x00) {
+	  			$tag = 0;
+	  			next;
+	  		}
+	  		elsif ($id == 0x0a) {
+	  			
+	  			my $num = unpack("V",substr($stuff,$cnt + 13,4));
+	  			my $str = substr($stuff,$cnt + 13 + 4,($num * 2));
+	  			$str =~ s/\00//g;
+	  			$item{name} = $str;
+	  		}
+	  		$cnt += $sz;
+	  	}
+	  }
+	  
+#		if (exists $segs{"{5cbf2787-48cf-4208-b90e-ee5e5d420294}"}) {
+#			my $stuff = $segs{"{5cbf2787-48cf-4208-b90e-ee5e5d420294}"};
+#	  	my $tag = 1;
+#	  	my $cnt = 0x10;
+#	  	while($tag) {
+#	  		my $sz = unpack("V",substr($stuff,$cnt,4));
+#	  		my $id = unpack("V",substr($stuff,$cnt + 4,4));
+#	  		
+#	  		if ($sz == 0x00) {
+#	  			$tag = 0;
+#	  			next;
+#	  		}
+#	  		elsif ($id == 0x19) {
+#	  			
+#	  			my $num = unpack("V",substr($stuff,$cnt + 13,4));
+#	  			my $str = substr($stuff,$cnt + 13 + 4,($num * 2));
+#	  			$str =~ s/\00//g;
+#	  			$item{name} = $str;
+#	  		}
+#	  		$cnt += $sz;
+#	  	}
+#		}
+	}
+	elsif (substr($data,4,4) eq "AugM") {
+		%item = parseFolderEntry($data);
+	}
+# Following two entries are for Device Property data	
+	elsif ($tag == 0x7b || $tag == 0xbb || $tag == 0xfb) {
+		my ($sz1,$sz2,$sz3) = unpack("VVV",substr($data,0x3e,12));
+		$item{name} = substr($data,0x4a,$sz1 * 2);
+		$item{name} =~ s/\00//g;
+	}
+	elsif ($tag == 0x02 || $tag == 0x03) {
+		my ($sz1,$sz2,$sz3,$sz4) = unpack("VVVV",substr($data,0x26,16));
+		$item{name} = substr($data,0x36,$sz1 * 2);
+		$item{name} =~ s/\00//g;
+	}
+	else {
+		$item{name} = "Unknown Type";	
+	}
+	return %item;
+}
+
+#-----------------------------------------------------------
+# parseNetworkEntry()
+#
+#-----------------------------------------------------------
+sub parseNetworkEntry {
+	my $data = shift;
+	my %item = ();	
+	$item{type} = unpack("C",substr($data,2,1));
+	
+	my @n = split(/\00/,substr($data,4,length($data) - 4));
+	$item{name} = $n[0];
+	return %item;
+}
+
+#-----------------------------------------------------------
+# parse01ShellItem()
+# I honestly have no idea what to do with this data; there's really
+# no reference for or description of the format of this data.  For
+# now, this is just a place holder
+#-----------------------------------------------------------
+sub parse01ShellItem {
+	my $data = shift;
+	my %item = ();
+	$item{type} = unpack("C",substr($data,2,1));;
+	$item{name} = "";
+#	($item{val0},$item{val1}) = unpack("VV",substr($data,2,length($data) - 2));
+	return %item;
+}
+
+#-----------------------------------------------------------
+#
+#-----------------------------------------------------------
+sub parseURIEntry {
+	my $data = shift;
+	my %item = ();
+	$item{type} = unpack("C",substr($data,2,1)); 	
+	
+	my ($lo,$hi) = unpack("VV",substr($data,0x0e,8));
+	$item{uritime} = ::getTime($lo,$hi);
+	
+	my $sz = unpack("V",substr($data,0x2a,4));
+	my $uri = substr($data,0x2e,$sz);
+	$uri =~ s/\00//g;
+	
+	my $proto = substr($data,length($data) - 6, 6);
+	$proto =~ s/\00//g;
+	
+	$item{name} = $proto."://".$uri." [".gmtime($item{uritime})."]";
+	
+	return %item;
+}
+
+#-----------------------------------------------------------
+#
+#-----------------------------------------------------------
+sub parseDriveEntry {
+	my $data     = shift;
+	my %item = ();
+	$item{type} = unpack("C",substr($data,2,1));;
+	$item{name} = substr($data,3,3);
+	return %item;
+}
+
+#-----------------------------------------------------------
+#
+#-----------------------------------------------------------
+sub parseControlPanelEntry {
+	my $data     = shift;
+	my %item = ();
+	$item{type} = unpack("C",substr($data,2,1));
+	my $guid = parseGUID(substr($data,14,16));
+	if (exists $cp_guids{$guid}) {
+		$item{name} = $cp_guids{$guid};
+	}
+	else {
+		$item{name} = $guid;
+	}
+	return %item;
+}
+
+#-----------------------------------------------------------
+#
+#-----------------------------------------------------------
+sub parseFolderEntry {
+	my $data     = shift;
+	my %item = ();
+	
+	$item{type} = unpack("C",substr($data,2,1));
+# Type 0x74 folders have a slightly different format	
+	
+	my $ofs_mdate;
+	my $ofs_shortname;
+	
+	if ($item{type} == 0x74) {
+		$ofs_mdate = 0x12;
+	}
+	elsif (substr($data,4,4) eq "AugM") {
+		$ofs_mdate = 0x1c;
+	}
+	else {
+		$ofs_mdate = 0x08;
+	}
+# some type 0x32 items will include a file size	
+	if ($item{type} == 0x32) {
+		my $size = unpack("V",substr($data,4,4));
+		if ($size != 0) {
+			$item{filesize} = $size;
+		}
+	}
+	
+	my @m = unpack("vv",substr($data,$ofs_mdate,4));
+	($item{mtime_str},$item{mtime}) = convertDOSDate($m[0],$m[1]);
+	
+# Need to read in short name; nul-term ASCII
+#	$item{shortname} = (split(/\00/,substr($data,12,length($data) - 12),2))[0];
+	$ofs_shortname = $ofs_mdate + 6;	
+	my $tag = 1;
+	my $cnt = 0;
+	my $str = "";
+	while($tag) {
+		my $s = substr($data,$ofs_shortname + $cnt,1);
+		if ($s =~ m/\00/ && ((($cnt + 1) % 2) == 0)) {
+			$tag = 0;
+		}
+		else {
+			$str .= $s;
+			$cnt++;
+		}
+	}
+#	$str =~ s/\00//g;
+	my $shortname = $str;
+	my $ofs = $ofs_shortname + $cnt + 1;
+# Read progressively, 1 byte at a time, looking for 0xbeef	
+	my $tag = 1;
+	my $cnt = 0;
+	while ($tag) {
+		if (unpack("v",substr($data,$ofs + $cnt,2)) == 0xbeef) {
+			$tag = 0;
+		}
+		else {
+			$cnt++;
+		}
+	}
+	$item{extver} = unpack("v",substr($data,$ofs + $cnt - 4,2));
+	$ofs = $ofs + $cnt + 2;
+	
+	my @m = unpack("vv",substr($data,$ofs,4));
+	($item{ctime_str},$item{ctime}) = convertDOSDate($m[0],$m[1]);
+	$ofs += 4;
+	my @m = unpack("vv",substr($data,$ofs,4));
+	($item{atime_str},$item{atime}) = convertDOSDate($m[0],$m[1]);
+	
+	my $jmp;
+	if ($item{extver} == 0x03) {
+		$jmp = 8;
+	}
+	elsif ($item{extver} == 0x07) {
+		$jmp = 26;
+	}
+	elsif ($item{extver} == 0x08) {
+		$jmp = 30;
+	}
+	else {}
+	
+	$ofs += $jmp;
+	
+	my $str = substr($data,$ofs,length($data) - 30);
+	my $longname = (split(/\00\00/,$str,2))[0];
+	$longname =~ s/\00//g;
+	
+	if ($longname ne "") {
+		$item{name} = $longname;
+	}
+	else {
+		$item{name} = $shortname;
+	}
+	return %item;
+}
+
+#-----------------------------------------------------------
+# convertDOSDate()
+# subroutine to convert 4 bytes of binary data into a human-
+# readable format.  Returns both a string and a Unix-epoch
+# time.
+#-----------------------------------------------------------
+sub convertDOSDate {
+	my $date = shift;
+	my $time = shift;
+	
+	if ($date == 0x00 || $time == 0x00){
+		return (0,0);
+	}
+	else {
+		my $sec = ($time & 0x1f) * 2;
+		$sec = "0".$sec if (length($sec) == 1);
+		if ($sec == 60) {$sec = 59};
+		my $min = ($time & 0x7e0) >> 5;
+		$min = "0".$min if (length($min) == 1);
+		my $hr  = ($time & 0xF800) >> 11;
+		$hr = "0".$hr if (length($hr) == 1);
+		my $day = ($date & 0x1f);
+		$day = "0".$day if (length($day) == 1);
+		my $mon = ($date & 0x1e0) >> 5;
+		$mon = "0".$mon if (length($mon) == 1);
+		my $yr  = (($date & 0xfe00) >> 9) + 1980;
+		my $gmtime = timegm($sec,$min,$hr,$day,($mon - 1),$yr);
+    return ("$yr-$mon-$day $hr:$min:$sec",$gmtime);
+#		return gmtime(timegm($sec,$min,$hr,$day,($mon - 1),$yr));
+	}
+}
+
+#-----------------------------------------------------------
+# parseFolderEntry2()
+#
+# Initial code for parsing type 0x35 
+#-----------------------------------------------------------
+sub parseFolderEntry2 {
+	my $data     = shift;
+	my %item = ();
+	
+	my $ofs = 0;
+	my $tag = 1;
+
+	while ($tag) {
+		if (unpack("v",substr($data,$ofs,2)) == 0xbeef) {
+			$tag = 0;
+		}
+		else {
+			$ofs++;
+		}
+	}
+	$item{extver} = unpack("v",substr($data,$ofs - 4,2));
+# Move offset over to end of where the ctime value would be
+	$ofs += 4;
+	
+	my $jmp;
+	if ($item{extver} == 0x03) {
+		$jmp = 8;
+	}
+	elsif ($item{extver} == 0x07) {
+		$jmp = 26;
+	}
+	elsif ($item{extver} == 0x08) {
+		$jmp = 30;
+	}
+	else {}
+	
+	$ofs += $jmp;
+	
+	my $str = substr($data,$ofs,length($data) - 30);
+	
+#	::rptMsg(" --- parseFolderEntry2 --- ");
+	my @d = printData($str);
+	foreach (0..(scalar(@d) - 1)) {
+#		::rptMsg($d[$_]);
+	}
+#	::rptMsg("");
+	
+	$item{name} = (split(/\00\00/,$str,2))[0];
+	$item{name} =~ s/\13\20/\2D\00/;
+	$item{name} =~ s/\00//g;
+	
+	return %item;
+}
+
+#-----------------------------------------------------------
+#
+#-----------------------------------------------------------
+sub parseNetworkEntry {
+	my $data     = shift;
+	my %item = ();
+	$item{type} = unpack("C",substr($data,2,1));
+	my @names = split(/\00/,substr($data,5,length($data) - 5));
+	$item{name} = $names[0];
+	return %item;
+}
+
+#-----------------------------------------------------------
+# printData()
+# subroutine used primarily for debugging; takes an arbitrary
+# length of binary data, prints it out in hex editor-style
+# format for easy debugging
+#-----------------------------------------------------------
+sub printData {
+	my $data = shift;
+	my $len = length($data);
+	my $tag = 1;
+	my $cnt = 0;
+	my @display = ();
+	
+	my $loop = $len/16;
+	$loop++ if ($len%16);
+	
+	foreach my $cnt (0..($loop - 1)) {
+#	while ($tag) {
+		my $left = $len - ($cnt * 16);
+		
+		my $n;
+		($left < 16) ? ($n = $left) : ($n = 16);
+
+		my $seg = substr($data,$cnt * 16,$n);
+		my @str1 = split(//,unpack("H*",$seg));
+
+		my @s3;
+		my $str = "";
+
+		foreach my $i (0..($n - 1)) {
+			$s3[$i] = $str1[$i * 2].$str1[($i * 2) + 1];
+			
+			if (hex($s3[$i]) > 0x1f && hex($s3[$i]) < 0x7f) {
+				$str .= chr(hex($s3[$i]));
+			}
+			else {
+				$str .= "\.";
+			}
+		}
+		my $h = join(' ',@s3);
+#		::rptMsg(sprintf "0x%08x: %-47s  ".$str,($cnt * 16),$h);
+		$display[$cnt] = sprintf "0x%08x: %-47s  ".$str,($cnt * 16),$h;
+	}
+	return @display;
+}
+1;

--- a/sift/files/windows-forensic-analysis/pref.pm
+++ b/sift/files/windows-forensic-analysis/pref.pm
@@ -1,0 +1,265 @@
+package pref;
+$VERSION = 0.1;
+#------------------------------------------------------
+# pref.pm
+# Perl module to parse Windows prefetch files
+# 
+# History:
+#  20130926 - updated to support Win8
+#
+# Ref:
+#  http://www.forensicswiki.org/wiki/Prefetch
+#  http://www.invoke-ir.com/2013/09/whats-new-in-prefetch-for-windows-8.html
+#
+# copyright 2013 Quantum Analytics Research, LLC
+# Author: H. Carvey keydet89@yahoo.com
+#------------------------------------------------------
+use strict;
+use vars qw($VERSION @ISA @EXPORT_OK);
+use Carp;
+
+require Exporter;
+
+@ISA         = qw(Exporter);
+@EXPORT_OK   = qw(new);
+
+my $self;				# self reference
+my @runtimes = ();
+my $data;
+
+#---------------------------------------------------------------------
+# new()
+# Opens file in binary mode; blesses self, including file handle
+# 
+#---------------------------------------------------------------------      	    
+sub new {
+	$self = {};
+	my $class = shift;
+	$self->{file} = shift;
+	
+	if (open(FH,"<",$self->{file})) {
+		binmode(FH);
+		seek(FH,4,0);
+		read(FH,$data,4);
+		$self->{sig} = $data;
+		getOffsets();
+		return bless $self;
+	}
+}
+
+
+sub getSig {
+	return $self->{sig};
+}
+
+#---------------------------------------------------------
+# getOffsets()
+# 0x98  - XP
+# 0xF0  - Vista/Win7
+# 0x130 - Win8
+#---------------------------------------------------------
+sub getOffsets {
+	if (open(FH,"<",$self->{file})) {
+		binmode(FH);
+		seek(FH,0,0);
+		read(FH,$data,8);
+		($self->{version},$self->{magic}) = unpack("VV",$data);
+
+# get the hash
+		seek(FH,0x4c,0);
+		read(FH,$data,4);
+		$self->{hash} = unpack("V",$data);
+
+# Get module path info (offset, size)
+		seek(FH,0x64,0);
+		read(FH,$data,8);
+		($self->{mod_ofs},$self->{mod_sz}) = unpack("VV",$data);		
+		
+# Get Volume Information Block offset		
+		seek(FH,0x6c,0);
+		read(FH,$data,4);
+		$self->{vib_ofs} = unpack("V",$data);
+		close(FH);
+# XP		
+		if ($self->{version} == 0x11) {
+			$self->{time_offset} = 0x78;
+			$self->{runcount_offset} = 0x90;
+		}
+# Vista/Win7		
+		elsif ($self->{version} == 0x17) {
+			$self->{time_offset} = 0x80;
+			$self->{runcount_offset} = 0x98;
+		}
+# Win8		
+		elsif ($self->{version} == 0x1A) {
+# for Win8, there are actually 8 FILETIME time stamps listed starting
+# at offset 0x80
+			$self->{time_offset} = 0x80;
+			$self->{runcount_offset} = 0xd0; 
+		}
+		else {
+# place holder			
+		}
+	}
+	else {
+# unable to open file		
+	}
+}
+
+#---------------------------------------------------------
+# getVersion()
+# 
+#---------------------------------------------------------
+sub getVersion {
+	return $self->{version};
+}
+
+#---------------------------------------------------------
+# getExeName()
+# get EXE name from .pf files
+#---------------------------------------------------------
+sub getExeName {
+	my $name;
+	my $tag = 1;
+	open(FH,"<",$self->{file});
+	binmode(FH);
+	seek(FH,0x10,0);
+	while ($tag) {
+		read(FH,$data,2);
+		$tag = 0 if (unpack("v",$data) == 0);
+		$name .= $data;
+	}
+	close(FH);
+	$name =~ s/\00//g;
+	return $name;
+}
+
+#---------------------------------------------------------
+# getMetaData()
+# get metadata from .pf files
+#---------------------------------------------------------
+sub getMetaData {
+	my ($runcount,$runtime);
+	my @tvals = ();
+	
+	open(FH,"<",$self->{file});
+	binmode(FH);
+# Windows 8 can have up to 8 times stored	
+	if ($self->{version} == 0x1A) {
+		foreach my $n (0..7) {
+			seek(FH,$self->{time_offset} + ($n * 8),0);
+			read(FH,$data,8);
+			@tvals = unpack("VV",$data);
+			
+			if ($tvals[0] == 0 && $tvals[1] == 0) {
+				
+				
+			}
+			else {
+				$runtimes[$n] = getTime($tvals[0],$tvals[1]);
+			}	
+		}
+		$runtime = $runtimes[0];
+	}
+	else {
+		seek(FH,$self->{time_offset},0);
+		read(FH,$data,8);
+		@tvals = unpack("VV",$data);
+		$runtime = getTime($tvals[0],$tvals[1]);
+	}
+
+	seek(FH,$self->{runcount_offset},0);
+	read(FH,$data,4);
+	$runcount = unpack("V",$data);
+	
+	close(FH);
+	return ($runcount,$runtime);
+}
+
+#---------------------------------------------------------
+# getRuntimes()
+# Win8 .pf files can have up to 8 runtimes, with the first
+# one being the most recent
+#---------------------------------------------------------
+sub getRuntimes {
+	return @runtimes;
+}
+
+#---------------------------------------------------------
+# getTime()
+# Get Unix-style date/time from FILETIME object
+# Input : 8 byte FILETIME object
+# Output: Unix-style date/time
+# Thanks goes to Andreas Schuster for the below code, which he
+# included in his ptfinder.pl
+#---------------------------------------------------------
+sub getTime {
+	my $lo = shift;
+	my $hi = shift;
+	my $t;
+
+	if ($lo == 0 && $hi == 0) {
+		$t = 0;
+	} else {
+		$lo -= 0xd53e8000;
+		$hi -= 0x019db1de;
+		$t = int($hi*429.4967296 + $lo/1e7);
+	};
+	$t = 0 if ($t < 0);
+	return $t;
+}
+
+#---------------------------------------------------------
+# getFilepaths()
+# Get list of Unicode file paths embedded in the .pf file
+#---------------------------------------------------------
+sub getPaths {
+	my ($ofs,$size);
+	my @paths;
+	
+	open(FH,"<",$self->{file});
+	binmode(FH);
+
+	seek(FH,$self->{mod_ofs},0);
+	read(FH,$data,$self->{mod_sz});
+	close(FH);
+
+	my @list = split(/\00\00/,$data);
+#print "Strings = ".scalar(@list)."\n";
+	foreach my $str (@list) {
+		$str =~ s/\00//g;
+		next if ($str eq "");
+		push(@paths,$str);
+	}
+	return @paths;
+}
+
+#---------------------------------------------------------
+# getVibData()
+# Get volume information block data embedded in the .pf file
+#---------------------------------------------------------
+sub getVibData {
+	my %vib_data;
+	
+	open(FH,"<",$self->{file});
+	binmode(FH);
+#	print "File: ".$self->{file}."\n";
+#	printf "VIB Offset = 0x%x\n",$self->{vib_ofs};
+	seek(FH,$self->{vib_ofs},0);
+	read(FH,$data,20);
+#	my ($path_ofs,$path_ln,$time0,$time1,$sn) = unpack("V5",$data);
+	my @vib = unpack("V5",$data);
+	seek(FH,$self->{vib_ofs} + $vib[0],0);
+	read(FH,$data,$vib[1] * 2);
+	$data =~ s/\00//g;
+	$vib_data{volumepath} = $data;
+	$vib_data{creationdate} = getTime($vib[2],$vib[3]);
+	
+	my $str = uc(sprintf "%x",$vib[4]);
+#	$vib_data{volumeserial} = substr($str,0,4)."-".substr($str,4,4);
+	$vib_data{volumeserial} = join('-',unpack("(A4)*",$str));
+	close(FH);
+	return %vib_data;
+}
+
+1;


### PR DESCRIPTION
This pull adds four Perl modules directly into `/usr/share/perl5`: JumpList.pm, LNK.pm, Pref.pm, and QuickTable.pm. These are done by adding the files into `sift/files/windows-forensic-analysis` and `sift/files/perl-modules`, then managing the files in two files under `sift/config/tools`. Should new versions be released in the future, the raw files would need to be updated. That said, they haven't been updated in 5-10 years each, so this likely will suffice.

The one Perl module not included is Win32::GUI which cannot build on Linux. 

With this pull request, all the tools in SIFT's #263 and #249 should work. I believe those tickets can be closed after this is merged.