### PR TITLE
Update and build sleuthkit, add supported image types

### DIFF
--- a/sift/packages/libvhdi-dev.sls
+++ b/sift/packages/libvhdi-dev.sls
@@ -1,0 +1,8 @@
+include:
+  - sift.repos.gift
+
+sift-package-libvhdi-dev:
+  pkg.installed:
+    - name: libvhdi-dev
+    - require:
+      - sls: sift.repos.gift

--- a/sift/packages/libvmdk-dev.sls
+++ b/sift/packages/libvmdk-dev.sls
@@ -1,0 +1,8 @@
+include:
+  - sift.repos.gift
+
+sift-package-libvmdk-dev:
+  pkg.installed:
+    - name: libvmdk-dev
+    - require:
+      - sls: sift.repos.gift

--- a/sift/packages/sleuthkit.sls
+++ b/sift/packages/sleuthkit.sls
@@ -1,10 +1,41 @@
+{%- set base_url = "https://github.com/sleuthkit/sleuthkit/releases/download/sleuthkit-" -%}
+{%- set version = "4.9.0" -%}
+{%- set filename = "sleuthkit-4.9.0.tar.gz" -%}
+{%- set hash = "7bc5ee9130b1ed8d645e446e0f63bd34ad018a93c1275688fa38cfda28bde9d0" -%}
+
 include:
   - sift.repos.gift
-  - sift.repos.sift
+  - sift.packages.libewf-dev
+  - sift.packages.libvmdk-dev
+  - sift.packages.libafflib-dev
+  - sift.packages.zlib1g-dev
+  - sift.packages.libvhdi-dev
+  - sift.packages.build-essential
 
-sift-package-sleuthkit:
-  pkg.latest:
-    - name: sleuthkit
-    - require:
-      - sls: sift.repos.sift
-      - sls: sift.repos.gift
+sift-packages-sleuthkit-source:
+  file.managed:
+    - name: "/var/cache/sift/archives/{{ filename }}"
+    - source: "{{ base_url }}{{ version }}/{{ filename }}"
+    - source_hash: sha256={{ hash }}
+    - makedirs: true
+
+sift-packages-sleuthkit-archive:
+  archive.extracted:
+    - name: /var/cache/sift/archives/
+    - source: "/var/cache/sift/archives/{{ filename }}"
+    - enforce_toplevel: true
+    - watch:
+      - file: sift-packages-sleuthkit-source
+
+sift-packages-sleuthkit-configure:
+  cmd.run:
+    - name: ./configure && make install
+    - cwd: /var/cache/sift/archives/sleuthkit-4.9.0
+    - watch:
+      - archive: sift-packages-sleuthkit-archive
+
+sift-packages-sleuthkit-rm-dir:
+  file.absent:
+    - name: /var/cache/sift/archives/sleuthkit-4.9.0
+    - watch:
+      - cmd: sift-packages-sleuthkit-configure

--- a/sift/packages/zlib1g-dev.sls
+++ b/sift/packages/zlib1g-dev.sls
@@ -1,0 +1,2 @@
+zlib1g-dev:
+  pkg.installed


### PR DESCRIPTION
The mmls build in the GIFT repo only supports RAW image types (mmls -i list). Supported image types can be added (vmdk, vhdi, aff, ewf etc.) when sleuthkit is built with the required -dev packages. 
These proposed states will instead pull the 4.9.0 release of sleuthkit, configure and make install, then clean up the extracted directory.
The downloaded archive is not removed, as some of the other states in the repo also appear to retain the archive, so the sleuthkit.sls state leaves the archive to mimic this behaviour.
Total run time is between 3-400 seconds, but would be worth it to add the ability to use sleuthkit on different image types without having to use additional tools.