### PR TITLE
Copy already downloaded PM's to required location

### DIFF
--- a/sift/scripts/keydet-tools.sls
+++ b/sift/scripts/keydet-tools.sls
@@ -2,7 +2,7 @@
 # license=unknown
 
 {% set files = ['bodyfile.pl','evtparse.pl','evtrpt.pl','evtxparse.pl','fb.pl','ff.pl','ff_signons.pl','ftkparse.pl','idx.pl','idxparse.pl','jl.pl','jobparse.pl','lfle.pl','lnk.pl','mft.pl','parse.pl','parsei30.pl','parseie.pl','pie.pl','pref.pl','rawie.pl','recbin.pl','regslack.pl','regtime.pl','rfc.pl','rlo.pl','tln.pl','usnj.pl'] -%}
-
+{% set modules = ['JumpList.pm','LNK.pm','pref.pm','Reg.pm'] %}
 include:
   - sift.packages.git
 
@@ -36,3 +36,22 @@ sift-scripts-keydet-tools-shebang-{{ file }}:
       - file: sift-scripts-keydet-tools-{{ file }}
 {%- endfor %}
 
+{%- for module in modules %}
+sift-scripts-keydet-tools-{{ module }}:
+  file.copy:
+    - name: /usr/share/perl5/{{ module }}
+    - source: /usr/local/src/keydet-tools/source/{{ module }}
+    - force: True
+    - mode: 0755
+    - require:
+      - git: sift-scripts-keydet-tools-git
+
+{%- endfor %}
+
+sift-scripts-keydet-tools-pref-pm:
+  file.rename:
+    - name: /usr/share/perl5/Pref.pm
+    - source: /usr/share/perl5/pref.pm
+    - force: True
+    - watch:
+      - file: sift-scripts-keydet-tools-pref.pm


### PR DESCRIPTION
The perl modules required for Keydet-tools are already available in the cloned repo in this state. Added the copy command to put them in the required location, and rename the pref.pm to Pref.pm (uppercase P) to ensure these tools function. Requires less overhead than managing the specific files locally.