### PR TITLE
Modify pip in appcompatprocessor.sls, update pdftk

### DIFF
--- a/sift/packages/default-jre.sls
+++ b/sift/packages/default-jre.sls
@@ -1,0 +1,2 @@
+default-jre:
+  pkg.installed

--- a/sift/packages/init.sls
+++ b/sift/packages/init.sls
@@ -23,6 +23,7 @@ include:
   - sift.packages.dc3dd
   - sift.packages.dcfldd
   - sift.packages.dconf-tools
+  - sift.packages.default-jre
   - sift.packages.docker
   - sift.packages.driftnet
   - sift.packages.dsniff
@@ -63,8 +64,10 @@ include:
   - sift.packages.lft
   - sift.packages.libafflib-dev
   - sift.packages.libafflib
+  - sift.packages.libbcprov-java
   - sift.packages.libbde
   - sift.packages.libbde-tools
+  - sift.packages.libcommons-lang3-java
   - sift.packages.libdatetime-perl
   - sift.packages.libesedb
   - sift.packages.libesedb-tools
@@ -124,7 +127,7 @@ include:
   - sift.packages.outguess
   - sift.packages.p0f
   - sift.packages.p7zip-full
-  - sift.packages.pdftk
+  - sift.packages.pdftk-java
   - sift.packages.perl
   - sift.packages.pev
   - sift.packages.phonon
@@ -222,6 +225,7 @@ sift-packages:
       - sls: sift.packages.dc3dd
       - sls: sift.packages.dcfldd
       - sls: sift.packages.dconf-tools
+      - sls: sift.packages.default-jre
       - sls: sift.packages.docker
       - sls: sift.packages.driftnet
       - sls: sift.packages.dsniff
@@ -262,8 +266,10 @@ sift-packages:
       - sls: sift.packages.lft
       - sls: sift.packages.libafflib-dev
       - sls: sift.packages.libafflib
+      - sls: sift.packages.libbcprov-java
       - sls: sift.packages.libbde
       - sls: sift.packages.libbde-tools
+      - sls: sift.packages.libcommons-lang3-java
       - sls: sift.packages.libdatetime-perl
       - sls: sift.packages.libesedb
       - sls: sift.packages.libesedb-tools
@@ -323,7 +329,7 @@ sift-packages:
       - sls: sift.packages.outguess
       - sls: sift.packages.p0f
       - sls: sift.packages.p7zip-full
-      - sls: sift.packages.pdftk
+      - sls: sift.packages.pdftk-java
       - sls: sift.packages.perl
       - sls: sift.packages.pev
       - sls: sift.packages.phonon

--- a/sift/packages/libbcprov-java.sls
+++ b/sift/packages/libbcprov-java.sls
@@ -1,0 +1,2 @@
+libbcprov-java:
+  pkg.installed

--- a/sift/packages/libcommons-lang3-java.sls
+++ b/sift/packages/libcommons-lang3-java.sls
@@ -1,0 +1,2 @@
+libcommons-lang3-java:
+  pkg.installed

--- a/sift/packages/pdftk-java.sls
+++ b/sift/packages/pdftk-java.sls
@@ -1,0 +1,13 @@
+include:
+  - sift.packages.default-jre
+  - sift.packages.libcommons-lang3-java
+  - sift.packages.libbcprov-java
+
+sift-packages-pdftk-java:
+  pkg.installed:
+    - sources: 
+        - pdftk-java: http://mirrors.kernel.org/ubuntu/pool/universe/p/pdftk-java/pdftk-java_3.0.2-2_all.deb
+    - require:
+        - sls: sift.packages.default-jre
+        - sls: sift.packages.libcommons-lang3-java
+        - sls: sift.packages.libbcprov-java

--- a/sift/packages/pdftk.sls
+++ b/sift/packages/pdftk.sls
@@ -1,8 +1,0 @@
-include:
-  - sift.packages.pdftk_{{ grains['oscodename'] }}
-
-sift-package-pdftk-distro:
-  test.nop:
-    - name: sift-package-pdftk-distro
-    - require:
-      - sls: sift.packages.pdftk_{{ grains['oscodename'] }}

--- a/sift/packages/pdftk_bionic.sls
+++ b/sift/packages/pdftk_bionic.sls
@@ -1,8 +1,0 @@
-include:
-  - sift.repos.malteworld
-
-sift-package-pdftk:
-  pkg.installed:
-    - name: pdftk
-    - require:
-      - sls: sift.repos.malteworld

--- a/sift/packages/pdftk_xenial.sls
+++ b/sift/packages/pdftk_xenial.sls
@@ -1,3 +1,0 @@
-sift-package-pdftk:
-  pkg.installed:
-    - name: pdftk

--- a/sift/python-packages/appcompatprocessor.sls
+++ b/sift/python-packages/appcompatprocessor.sls
@@ -1,14 +1,10 @@
-{%- set commit="46ba76a73fcf71640f2a6e9db02afaaac3e178b9" -%}
 include:
   - sift.packages.git
   - sift.packages.python-pip
 
 appcompatprocessor:
   pip.installed:
-    - name: git+https://github.com/mbevilacqua/appcompatprocessor.git@{{ commit }}
-    {% if grains['oscodename'] == "bionic" -%}
-    - pip_bin: /usr/bin/pip
-    {% endif -%}
+    - name: git+https://github.com/mbevilacqua/appcompatprocessor.git
     - require:
       - sls: sift.packages.git
       - sls: sift.packages.python-pip


### PR DESCRIPTION
Specific pointer in appcompatprocessor.sls to /usr/bin/pip can cause conflict with locally installed pip. Using the salt-based pip uses 'python2 -m pip' which is more preferable for this installation. Also removed the specific git commit as the tool has been updated for additional support for Windows 10.

The pdftk installation from malteworld repo has been removed (unsure if permanent), making it impossible to install pdftk from the repo. Added pdftk-java state to compensate for this, allowing for a direct download of the deb package, then local install with requirements. 

Updated the init.sls, did not remove the repo (in the event pdftk is returned).

These two fixes should resolve the issues in issue 460.