### PR TITLE
Set CPAN to accept defaults using env variable during quicktable install

### DIFF
--- a/sift/perl-packages/quicktable.sls
+++ b/sift/perl-packages/quicktable.sls
@@ -5,6 +5,8 @@ include:
 sift-perl-packages-quicktable:
   cmd.run:
     - name: cpan install HTML::QuickTable
+    - env:
+      - PERL_MM_USE_DEFAULT: 1
     - require:
       - sls: sift.packages.perl
       - sls: sift.packages.build-essential


### PR DESCRIPTION
cpan stalls on installation of HTML::QuickTable due to prompt for choices. Added the env variable for the cmd.run "PERL_MM_USE_DEFAULT: 1" to ensure that cpan essentially 'says yes' to the prompts which cause it to stall.