### PR TITLE
Pinned distorm3 to 3.4.4 due to volatility errors

### DIFF
--- a/sift/python-packages/distorm3.sls
+++ b/sift/python-packages/distorm3.sls
@@ -1,7 +1,9 @@
 include:
-  - ..packages.python-pip
+  - sift.packages.python-pip
 
 distorm3:
   pip.installed:
+    - name: distorm3 == 3.4.4
+    - bin_env: /usr/bin/python
     - require:
       - pkg: python-pip

--- a/sift/python-packages/volatility_bionic.sls
+++ b/sift/python-packages/volatility_bionic.sls
@@ -20,7 +20,7 @@ include:
 sift-python-volatility:
   pip.installed:
     - name: git+https://github.com/volatilityfoundation/volatility.git@2.6.1
-    - pip_bin: /usr/bin/pip
+    - bin_env: /usr/bin/python
     - require:
       - sls: sift.packages.git
       - sls: sift.packages.python-pip


### PR DESCRIPTION
Due to a recent update in distorm3, volatility becomes broken after install [identified here](https://github.com/volatilityfoundation/volatility/issues/719). This was observed and validated in my most recent install of SIFT (3 days ago).

Modified the distorm3 state to pin the distorm3 version to 3.4.4 to resolve the issue. Also specified the bin_env explicitly, as I noticed the teamdfir/sift-saltstack-tester has upgraded to 3001, and the bin_env will be required for that version (being python3-based). 
Also updated the volatility_bionic state to change pip_bin in favor of bin_env since [pip_bin is deprecated](https://docs.saltstack.com/en/master/ref/states/all/salt.states.pip_state.html).

Did not update the volatility_xenial state since, unless I'm mistaken, 16.04 is no longer supported using the sift-cli.