### PR TITLE
Fix for regripper issues during update/upgrade

### DIFF
--- a/sift/scripts/regripper.sls
+++ b/sift/scripts/regripper.sls
@@ -1,6 +1,10 @@
-# source=https://github.com/keydet89/RegRipper2.8
-# license=mit
-# license_source=https://github.com/keydet89/RegRipper2.8/blob/master/license.md
+# Name: regripper
+# Website: https://github.com/keydet89/RegRipper3.0
+# Description: Registry parsing toolsuite
+# Category: 
+# Author: Harlan Carvey
+# License: MIT License (https://github.com/keydet89/RegRipper3.0/blob/master/license.md)
+# Notes: rip.pl
 
 include:
   - sift.packages.git
@@ -28,11 +32,51 @@ sift-scripts-regripper-directory:
 sift-scripts-regripper-binary:
   file.managed:
     - name: /usr/share/regripper/rip.pl
-    - source: salt://sift/files/regripper/rip.pl
+    - source: /usr/local/src/regripper/rip.pl
     - mode: 755
     - require:
       - git: sift-scripts-regripper-git
       - pkg: libparse-win32registry-perl
+
+sift-scripts-regripper-perl-header:
+  file.replace:
+    - name: /usr/share/regripper/rip.pl
+    - pattern: '#! c:\\perl\\bin\\perl.exe'
+    - repl: '#!/usr/bin/perl'
+    - count: 1
+    - prepend_if_not_found: True
+    - require:
+      - file: sift-scripts-regripper-binary
+
+sift-scripts-regripper-plugins-path:
+  file.replace:
+    - name: /usr/share/regripper/rip.pl
+    - pattern: 'my \$plugindir;'
+    - repl: 'my $plugindir = "/usr/share/regripper/plugins/";'
+    - count: 1
+    - prepend_if_not_found: False
+    - require:
+      - file: sift-scripts-regripper-binary
+
+sift-scripts-regripper-plugins-path-cleanup:
+  file.replace:
+    - name: /usr/share/regripper/rip.pl
+    - pattern: '\(\$\^O eq "MSWin32"\) \? \(\$plugindir = \$str."plugins/"\)'
+    - repl: '#($^O eq "MSWin32") ? ($plugindir = $str."plugins/")'
+    - count: 1
+    - prepend_if_not_found: False
+    - require:
+      - file: sift-scripts-regripper-binary
+
+sift-scripts-regripper-plugins-cleanup-2:
+  file.replace:
+    - name: /usr/share/regripper/rip.pl
+    - pattern: ': \(\$plugindir = File::Spec->catfile\("plugins"\)\);'
+    - repl: '#: ($plugindir = File::Spec->catfile("plugins"));'
+    - count: 1
+    - prepend_if_not_found: False
+    - require:
+      - file: sift-scripts-regripper-binary
 
 sift-scripts-regripper-plugins-symlink:
   file.symlink:


### PR DESCRIPTION
Even though RegRipper has been updated to 3.0, the regripper.sls state keeps copying the rip.pl file found in sift/files/regripper over to the installation, causing the rip.pl file to remain at the 2008 version. 
Updates to this state will allow for the up-to-date changes made to the RegRipper3.0 repo to remain, without reliance on a specific version of the file in the SIFT repo.

This state will:
- Replace the rip.pl header of C:\perl\bin\perl.exe with /usr/bin/perl
- Assign a static entry to the my $plugindir statement
- Comment out the two following lines for the $plugindir assignment, thus allowing the static assignment to remain.

I will note here that there appears to be an error with the mountdev2 plugin as well regarding an unclosed curly brace and regex. I opted not to fix that here, as I will submit a pull request on the keydet89/RegRipper3.0 repo to fix this plugin.

Finally, I added the header for the state, since I was going to have to do it anyways, now just seemed like a good time to do it.