### PR TITLE
Updated pstotal, requirement for openpyxl

### DIFF
--- a/sift/files/volatility/pstotal.py
+++ b/sift/files/volatility/pstotal.py
@@ -56,21 +56,21 @@ class pstotal(common.AbstractWindowsCommand):
     def render_text(self, outfd, data):
         processes = data[0]
         interest = data[1]
-        outfd.write("Offset (P)     Name          PID    PPID   PDB        Time created             Time exited             Interesting \n" + \
-                    "---------- ---------------- ------ ------ ---------- ------------------------ ------------------------ ----------- \n")
-
-        if interest[processes[eprocess].obj_offset] == 1:
-            interesting = 'TRUE'
-        else:
-            interesting = ' '
-        outfd.write("0x{0:08x} {1:16} {2:6} {3:6} 0x{4:08x} {5:24} {6:24} {7:7}\n".format(
-                processes[eprocess].obj_offset,
-                processes[eprocess].ImageFileName,
-                processes[eprocess].UniqueProcessId,
-                processes[eprocess].InheritedFromUniqueProcessId,
-                processes[eprocess].Pcb.DirectoryTableBase,
-                processes[eprocess].CreateTime or '',
-                processes[eprocess].ExitTime or '', interesting))
+        outfd.write("Offset (P)  Name             PID    PPID   PDB         Time created                 Time exited                  Interesting \n" + \
+                    "----------- ---------------- ------ ------ ----------- ---------------------------- ---------------------------- ----------- \n")
+        for eprocess in processes:
+            if interest[processes[eprocess].obj_offset] == 1:
+                interesting = 'TRUE'
+            else:
+                interesting = ' '
+            outfd.write("0x{0:09x} {1:16} {2:6} {3:6} 0x{4:09x} {5:28} {6:28} {7:7}\n".format(
+                    processes[eprocess].obj_offset,
+                    processes[eprocess].ImageFileName,
+                    processes[eprocess].UniqueProcessId,
+                    processes[eprocess].InheritedFromUniqueProcessId,
+                    processes[eprocess].Pcb.DirectoryTableBase,
+                    processes[eprocess].CreateTime or '',
+                    processes[eprocess].ExitTime or '', interesting))
             
     def render_dot(self, outfd, data):
         objects = set()

--- a/sift/python-packages/openpyxl.sls
+++ b/sift/python-packages/openpyxl.sls
@@ -1,0 +1,10 @@
+include:
+  - sift.packages.python2-pip
+  - sift.packages.python3-pip
+
+openpyxl==2.1.2:
+  pip.installed:
+    - bin_env: /usr/bin/python2
+    - upgrade: True
+    - require:
+      - sls: sift.packages.python2-pip

--- a/sift/python-packages/volatility.sls
+++ b/sift/python-packages/volatility.sls
@@ -11,6 +11,7 @@ include:
   - sift.python-packages.distorm3
   - sift.python-packages.ioc_writer
   - sift.python-packages.lxml
+  - sift.python-packages.openpyxl
   - sift.python-packages.pefile
   - sift.python-packages.pycoin
   - sift.python-packages.pycrypto
@@ -48,6 +49,7 @@ sift-python-volatility-community-plugins:
       - sls: sift.python-packages.distorm3
       - sls: sift.python-packages.ioc_writer
       - sls: sift.python-packages.lxml
+      - sls: sift.python-packages.openpyxl
       - sls: sift.python-packages.pefile
       - sls: sift.python-packages.pycoin
       - sls: sift.python-packages.pycrypto


### PR DESCRIPTION
Noticed that openpyxl was missing for timeliner output to XLSX. While the latest version is 3.0.5, the volatility renderers only support openpyxl 2.1.2, so I pinned the state to that. It wasn't added to the init.sls as it's only required by Volatility.

Updated the pstotal plugin as recommended by [@Pitteuchar](https://github.com/teamdfir/sift/issues/269#issuecomment-410028231) in Issue [#269](https://github.com/teamdfir/sift/issues/269).
