### PR TITLE
Force plaso to bind to python3-redis

### DIFF
--- a/sift/packages/init.sls
+++ b/sift/packages/init.sls
@@ -151,6 +151,7 @@ include:
   - sift.packages.python3-dfvfs
   - sift.packages.python3-pip
   - sift.packages.python3-plaso
+  - sift.packages.python3-redis
   - sift.packages.python3-xlsxwriter
   - sift.packages.qemu
   - sift.packages.qemu-utils
@@ -344,6 +345,7 @@ sift-packages:
       - sls: sift.packages.python3-pefile
       - sls: sift.packages.python3-pip
       - sls: sift.packages.python3-plaso
+      - sls: sift.packages.python3-redis
       - sls: sift.packages.python3-pytsk3
       - sls: sift.packages.python3-pyqt5
       - sls: sift.packages.python3-tk

--- a/sift/packages/python3-plaso.sls
+++ b/sift/packages/python3-plaso.sls
@@ -5,6 +5,7 @@ include:
   - sift.packages.python3
   - sift.packages.python3-xlsxwriter
   - sift.packages.python3-dfvfs
+  - sift.packages.python3-redis
 
 sift-package-python3-plaso:
   pkg.installed:
@@ -21,3 +22,4 @@ sift-package-python3-plaso:
       - sls: sift.packages.python3
       - sls: sift.packages.python3-xlsxwriter
       - sls: sift.packages.python3-dfvfs
+      - sls: sift.packages.python3-redis

--- a/sift/packages/python3-redis.sls
+++ b/sift/packages/python3-redis.sls
@@ -1,0 +1,7 @@
+include:
+  - sift.repos.gift
+
+python3-redis:
+  pkg.installed:
+    - require:
+      - sls: sift.repos.gift


### PR DESCRIPTION
Came across [this issue](https://github.com/log2timeline/plaso/issues/3163) with a few fresh installs today (docker, dedicated VM, addon VM). python3-redis and pip3's redis are both getting installed based on requirements, but the pip3 version isn't updating to the latest version (it's sticking to 3.3.11). By pinning to the GIFT version of python3-redis, this will guarantee that python3-plaso has the correct version of redis to continue processing.