### PR TITLE
Include python3-pip for salt requirement

### DIFF
--- a/sift/python-packages/pillow.sls
+++ b/sift/python-packages/pillow.sls
@@ -1,5 +1,6 @@
 include:
   - sift.packages.python2-pip
+  - sift.packages.python3-pip
 
 sift-python-packages-pillow:
   pip.installed:


### PR DESCRIPTION
While pillow will install with the volatility state because it includes the python3-pip, the pillow state alone will not install without the python3-pip binary. 
Added the sift.packages.python3-pip include statement to ensure compatibility with salt.

This pull does not require a new release, as volatility and pillow will install correctly. This is just more for upkeep.