### PR TITLE
Salt ID's conflicting

### DIFF
--- a/sift/python3-packages/pillow.sls
+++ b/sift/python3-packages/pillow.sls
@@ -1,7 +1,7 @@
 include:
   - sift.packages.python3-pip
 
-sift-python-packages-pillow:
+sift-python3-packages-pillow:
   pip.installed:
     - name: pillow
     - bin_env: /usr/bin/python3


### PR DESCRIPTION
SLS ID's in Salt should be unique across states, and unfortunately this ID (sift-python-packages-pillow) exists in both the python2 and python3 version. Updated the python3 state to read sift-python3-packages-pillow.