### PR TITLE
Fix capstone installation

### DIFF
--- a/sift/python-packages/capstone.sls
+++ b/sift/python-packages/capstone.sls
@@ -2,6 +2,10 @@ include:
   - sift.packages.python3-pip
   - sift.packages.python2-pip
 
+sift-python-packages-pkg-remove:
+  pkg.removed:
+    - name: python-capstone
+
 sift-python-packages-capstone:
   pip.installed:
     - name: capstone

--- a/sift/python-packages/capstone.sls
+++ b/sift/python-packages/capstone.sls
@@ -13,3 +13,4 @@ sift-python-packages-capstone:
     - upgrade: True
     - require:
       - sls: sift.packages.python2-pip
+      - pkg: sift-python-packages-pkg-remove


### PR DESCRIPTION
Python-capstone is no longer up-to-date with the current python2 capstone, so it was removed in favor of the pip capstone. However, if not removed through APT pkg manager, pip can't install capstone properly.

Modified the state to remove python-capstone first, then install capstone using pip.