### PR TITLE
Fix sqlite_miner requirements, update

### DIFF
--- a/sift/perl-packages/dbd-sqlite.sls
+++ b/sift/perl-packages/dbd-sqlite.sls
@@ -1,0 +1,12 @@
+include:
+  - sift.packages.perl
+  - sift.packages.build-essential
+
+sift-perl-packages-dbd-sqlite:
+  cmd.run:
+    - name: cpanm --no-man-pages install DBD::SQLite
+    - env:
+      - PERL_MM_USE_DEFAULT: 1
+    - require:
+      - sls: sift.packages.perl
+      - sls: sift.packages.build-essential

--- a/sift/perl-packages/init.sls
+++ b/sift/perl-packages/init.sls
@@ -4,6 +4,7 @@ include:
   - sift.perl-packages.exiftool
   - sift.perl-packages.json
   - sift.perl-packages.xpath
+  - sift.perl-packages.dbd-sqlite
 
 sift-perl-packages:
   test.nop:
@@ -14,3 +15,4 @@ sift-perl-packages:
       - sls: sift.perl-packages.exiftool
       - sls: sift.perl-packages.json
       - sls: sift.perl-packages.xpath
+      - sls: sift.perl-packages.dbd-sqlite

--- a/sift/scripts/sqlite_miner.sls
+++ b/sift/scripts/sqlite_miner.sls
@@ -1,12 +1,18 @@
-# source=https://github.com/threeplanetssoftware/sqlite_miner
-# license=GNUv3
+# Name: sqlite_miner
+# Website: https://github.com/threeplanetssoftware/sqlite_miner
+# Description: A script to mine SQLite databases for hidden gems that might be overlooked 
+# Category: 
+# Author: Jon Baumann, Ciofeca Forensics
+# License: GNU General Public License v3.0 (https://github.com/threeplanetssoftware/sqlite_miner/blob/master/LICENSE)
+# Notes: sqlite_miner.pl, fun_stuff.pl
 
 {% set commit     = "4220dae48a6e45c1316b153231dc6beef36f2f59" -%}
 {% set hash_fun   = "sha256=c2e887dc62cb8191e0333f95d2e0eee330f62a778abf394f2ae158be39e44590" -%}
-{% set hash_miner = "sha256=19ed304989d7963b80530367caf4113810a55910147a7af41160d7f584614505" -%}
+{% set hash_miner = "sha256=0d4b380a27dd57380b581224b1258fbd5059b9314d59aa7ee2f260d352f82278" -%}
 
 include:
   - sift.packages.perl
+  - sift.perl-packages.dbd-sqlite
 
 sift-scripts-sqlite-miner-funstuff:
   file.managed:
@@ -20,11 +26,12 @@ sift-scripts-sqlite-miner-funstuff:
 sift-scripts-sqlite-miner:
   file.managed:
     - name: /usr/local/bin/sqlite_miner.pl
-    - source: https://raw.githubusercontent.com/threeplanetssoftware/sqlite_miner/{{ commit }}/sqlite_miner.pl
+    - source: https://raw.githubusercontent.com/threeplanetssoftware/sqlite_miner/master/sqlite_miner.pl
     - source_hash: {{ hash_miner }}
     - mode: 755
     - require:
       - sls: sift.packages.perl
+      - sls: sift.perl-packages.dbd-sqlite
 
 sift-scripts-sqlite-miner-shebang:
   file.prepend:
@@ -32,4 +39,3 @@ sift-scripts-sqlite-miner-shebang:
     - text: '#!/usr/bin/env perl'
     - watch:
       - file: sift-scripts-sqlite-miner
-


### PR DESCRIPTION
When running sqlite_miner on an sqlite file, it errors out with a statement that it is missing DBD/SQLite.pm
Added the DBD::SQLite state, updated the version of sqlite_miner.pl (pulling now from master), and added a header (without category at this time).