### PR TITLE
Update python2-pip to pull from 2.7 folder

### DIFF
--- a/sift/packages/python2-pip.sls
+++ b/sift/packages/python2-pip.sls
@@ -12,7 +12,7 @@ sift-package-python2-pip:
 {%- elif grains['oscodename'] == "focal" %}
 sift-package-python2-pip-install-script:
   cmd.run:
-    - name: curl -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py 
+    - name: curl -o /tmp/get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py 
     - unless: which pip2
     - require:
       - sls: sift.packages.python2


### PR DESCRIPTION
This will fix the python2 get-pip.py error that popped up in the last few days. It pulls from a specific 2.7 folder at bootstrap.pypa.io, give the root one (which is now configured for Python3).