### PR TITLE
Added Accessibility tools as per #500

### DIFF
--- a/sift/packages/init.sls
+++ b/sift/packages/init.sls
@@ -109,6 +109,7 @@ include:
   - sift.packages.libvshadow-tools
   - sift.packages.libxml2-dev
   - sift.packages.libxslt-dev
+  - sift.packages.magnus
   - sift.packages.nbd-client
   - sift.packages.nbtscan
   - sift.packages.netcat
@@ -120,10 +121,12 @@ include:
   - sift.packages.ngrep
   - sift.packages.nikto
   - sift.packages.okular
+  - sift.packages.onboard
   - sift.packages.open-iscsi
   - sift.packages.openjdk
   - sift.packages.ophcrack
   - sift.packages.ophcrack-cli
+  - sift.packages.orca
   - sift.packages.outguess
   - sift.packages.p0f
   - sift.packages.p7zip-full
@@ -311,6 +314,7 @@ sift-packages:
       - sls: sift.packages.libvshadow-tools
       - sls: sift.packages.libxml2-dev
       - sls: sift.packages.libxslt-dev
+      - sls: sift.packages.magnus
       - sls: sift.packages.nbd-client
       - sls: sift.packages.nbtscan
       - sls: sift.packages.netcat
@@ -322,10 +326,12 @@ sift-packages:
       - sls: sift.packages.ngrep
       - sls: sift.packages.nikto
       - sls: sift.packages.okular
+      - sls: sift.packages.onboard
       - sls: sift.packages.open-iscsi
       - sls: sift.packages.openjdk
       - sls: sift.packages.ophcrack
       - sls: sift.packages.ophcrack-cli
+      - sls: sift.packages.orca
       - sls: sift.packages.outguess
       - sls: sift.packages.p0f
       - sls: sift.packages.p7zip-full

--- a/sift/packages/magnus.sls
+++ b/sift/packages/magnus.sls
@@ -1,0 +1,22 @@
+# Name: magnus
+# Website: https://github.com/stuartlangridge/magnus
+# Description: Simple screen magnifier for Ubuntu 
+# Category: 
+# Author: Stuart Langridge, Martin Wimpress
+# License: MIT License (https://github.com/stuartlangridge/magnus/blob/master/LICENSE)
+# Notes: magnus
+
+{%- if grains['oscodename'] == "bionic" %}
+include:
+  - sift.repos.flexiondotorg
+
+magnus:
+  pkg.installed:
+    - require:
+      - sls: sift.repos.flexiondotorg
+
+{%- elif grains['oscodename'] == "focal" %}
+magnus:
+  pkg.installed
+
+{%- endif -%}

--- a/sift/packages/onboard.sls
+++ b/sift/packages/onboard.sls
@@ -1,0 +1,2 @@
+onboard:
+  pkg.installed

--- a/sift/packages/orca.sls
+++ b/sift/packages/orca.sls
@@ -1,0 +1,2 @@
+orca:
+  pkg.installed

--- a/sift/repos/flexiondotorg.sls
+++ b/sift/repos/flexiondotorg.sls
@@ -1,0 +1,10 @@
+include:
+  - sift.packages.software-properties-common
+
+flexiondotorg-repo:
+  pkgrepo.managed:
+    - ppa: flexiondotorg/magnus
+    - keyserver: hkp://p80.pool.sks-keyservers.net:80
+    - refresh: true
+    - require:
+      - sls: sift.packages.software-properties-common


### PR DESCRIPTION
This will add the three tools recommended by @philhagen in SIFT Issue [#500](https://github.com/teamdfir/sift/issues/500): magnus, orca, and onboard. 

I've configured the state to add the repo for magnus then install the pkg for Ubuntu 18 (to avoid the snap), but for Ubuntu 20 this isn't needed, since magnus is in the apt package listing. This does create a minor versioning gap as installing from the flexiondotorg repo in 18 gives version 1.0.2, but installing from APT in 20 gives 1.0.3. 

