### PR TITLE
Fix pyhindsight and python3 packages

### DIFF
--- a/sift/python3-packages/argparse.sls
+++ b/sift/python3-packages/argparse.sls
@@ -1,10 +1,9 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
 
 sift-python3-packages-argparse:
   pip.installed:
     - name: argparse
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip

--- a/sift/python3-packages/bitstring.sls
+++ b/sift/python3-packages/bitstring.sls
@@ -1,10 +1,9 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
 
 sift-python3-packages-bitstring:
   pip.installed:
     - name: bitstring
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip

--- a/sift/python3-packages/colorama.sls
+++ b/sift/python3-packages/colorama.sls
@@ -1,10 +1,9 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
 
 sift-python3-packages-colorama:
   pip.installed:
     - name: colorama
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip

--- a/sift/python3-packages/defang.sls
+++ b/sift/python3-packages/defang.sls
@@ -1,11 +1,11 @@
 # WEBSITE: https://github.com/HurricaneLabs/machinae
 # LICENSE: MIT
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
 
 sift-python3-packages-defang:
   pip.installed:
     - name: defang==0.5.2
     - bin_env: /usr/bin/python3
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip

--- a/sift/python3-packages/geoip2.sls
+++ b/sift/python3-packages/geoip2.sls
@@ -1,10 +1,9 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
 
 sift-python3-packages-geoip2:
   pip.installed:
     - name: geoip2
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip

--- a/sift/python3-packages/ioc_writer.sls
+++ b/sift/python3-packages/ioc_writer.sls
@@ -1,5 +1,5 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
   - sift.python3-packages.lxml
   - sift.python3-packages.yara-python
 
@@ -7,8 +7,7 @@ sift-python3-packages-ioc-writer:
   pip.installed:
     - name: ioc_writer
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip
       - sls: sift.python3-packages.lxml
       - sls: sift.python3-packages.yara-python

--- a/sift/python3-packages/keyrings-alt.sls
+++ b/sift/python3-packages/keyrings-alt.sls
@@ -1,10 +1,9 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
 
 sift-python3-packages-keyrings-alt:
   pip.installed:
     - name: keyrings.alt
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip

--- a/sift/python3-packages/lxml.sls
+++ b/sift/python3-packages/lxml.sls
@@ -1,5 +1,5 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
   - sift.packages.libxml2-dev
   - sift.packages.libxslt-dev
 
@@ -7,8 +7,7 @@ sift-python3-packages-lxml:
   pip.installed:
     - name: lxml
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip
       - sls: sift.packages.libxml2-dev
       - sls: sift.packages.libxslt-dev

--- a/sift/python3-packages/machinae.sls
+++ b/sift/python3-packages/machinae.sls
@@ -1,7 +1,7 @@
 # WEBSITE: https://github.com/HurricaneLabs/machinae
 # LICENSE: MIT
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
   - sift.python3-packages.defang
 
 sift-python3-packages-machinae:
@@ -9,5 +9,5 @@ sift-python3-packages-machinae:
     - name: machinae
     - bin_env: /usr/bin/python3
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip
       - sls: sift.python3-packages.defang

--- a/sift/python3-packages/pillow.sls
+++ b/sift/python3-packages/pillow.sls
@@ -1,10 +1,9 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
 
 sift-python3-packages-pillow:
   pip.installed:
     - name: pillow
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip

--- a/sift/python3-packages/pip.sls
+++ b/sift/python3-packages/pip.sls
@@ -1,0 +1,9 @@
+include:
+  - sift.packages.python3-pip
+
+sift-python3-packages-pip:
+  pip.installed:
+    - name: pip==21.0.1
+    - bin_env: /usr/bin/python3
+    - require:
+      - sls: sift.packages.python3-pip

--- a/sift/python3-packages/pyhindsight.sls
+++ b/sift/python3-packages/pyhindsight.sls
@@ -1,14 +1,15 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
+  - sift.python3-packages.setuptools-rust
   - sift.python3-packages.keyrings-alt
   
 sift-python3-packages-pyhindsight:
   pip.installed:
     - name: pyhindsight
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip
+      - sls: sift.python3-packages.setuptools-rust
       - sls: sift.python3-packages.keyrings-alt
 
 sift-python3-packages-pyhindsight-encoding:

--- a/sift/python3-packages/python-dateutil.sls
+++ b/sift/python3-packages/python-dateutil.sls
@@ -1,10 +1,9 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
 
 sift-python3-packages-python-dateutil:
   pip.installed:
     - name: python-dateutil
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip

--- a/sift/python3-packages/python-evtx.sls
+++ b/sift/python3-packages/python-evtx.sls
@@ -1,10 +1,9 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
 
 sift-python3-packages-python-evtx:
   pip.installed:
     - name: python-evtx
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip

--- a/sift/python3-packages/python-magic.sls
+++ b/sift/python3-packages/python-magic.sls
@@ -1,10 +1,9 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
 
 sift-python3-packages-python-magic:
   pip.installed:
     - name: python-magic
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip

--- a/sift/python3-packages/python-registry.sls
+++ b/sift/python3-packages/python-registry.sls
@@ -1,10 +1,9 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
 
 sift-python3-packages-python-registry:
   pip.installed:
     - name: python-registry
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip

--- a/sift/python3-packages/setuptools-rust.sls
+++ b/sift/python3-packages/setuptools-rust.sls
@@ -1,10 +1,9 @@
 include:
   - sift.python3-packages.pip
 
-sift-python3-packages-pefile:
+sift-python3-packages-setuptools-rust:
   pip.installed:
-    - name: pefile
+    - name: setuptools_rust
     - bin_env: /usr/bin/python3
     - require:
       - sls: sift.python3-packages.pip
-

--- a/sift/python3-packages/setuptools.sls
+++ b/sift/python3-packages/setuptools.sls
@@ -1,10 +1,9 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
 
 sift-python3-packages-setuptools:
   pip.installed:
     - name: setuptools
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip

--- a/sift/python3-packages/six.sls
+++ b/sift/python3-packages/six.sls
@@ -1,10 +1,9 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
 
 sift-python3-packages-six:
   pip.installed:
     - name: six
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip

--- a/sift/python3-packages/stix-validator.sls
+++ b/sift/python3-packages/stix-validator.sls
@@ -1,12 +1,11 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
   - sift.python3-packages.stix
 
 sift-python3-packages-stix-validator:
   pip.installed:
     - name: stix-validator
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip
       - sls: sift.python3-packages.stix

--- a/sift/python3-packages/stix.sls
+++ b/sift/python3-packages/stix.sls
@@ -1,12 +1,11 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
   - sift.python3-packages.lxml
 
 sift-python3-packages-stix:
   pip.installed:
     - name: stix
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip
       - sls: sift.python3-packages.lxml

--- a/sift/python3-packages/upgrade.sls
+++ b/sift/python3-packages/upgrade.sls
@@ -1,3 +1,24 @@
+argparse.sls:    - upgrade: True
+bitstring.sls:    - upgrade: True
+colorama.sls:    - upgrade: True
+geoip2.sls:    - upgrade: True
+ioc_writer.sls:    - upgrade: True
+lxml.sls:    - upgrade: True
+pefile.sls:    - upgrade: True
+pillow.sls:    - upgrade: True
+pyhindsight.sls:    - upgrade: True
+python-dateutil.sls:    - upgrade: True
+python-evtx.sls:    - upgrade: True
+python-magic.sls:    - upgrade: True
+python-registry.sls:    - upgrade: True
+setuptools.sls:    - upgrade: True
+six.sls:    - upgrade: True
+stix-validator.sls:    - upgrade: True
+stix.sls:    - upgrade: True
+virustotal-api.sls:    - upgrade: True
+wheel.sls:    - upgrade: True
+yara-python.sls:    - upgrade: True
+
 include:
   - sift.python3-packages.pip
   - sift.python3-packages.argparse
@@ -5,9 +26,7 @@ include:
   - sift.python3-packages.colorama
   - sift.python3-packages.geoip2
   - sift.python3-packages.ioc_writer
-  - sift.python3-packages.keyrings-alt
   - sift.python3-packages.lxml
-  - sift.python3-packages.machinae
   - sift.python3-packages.pefile
   - sift.python3-packages.pillow
   - sift.python3-packages.pyhindsight
@@ -24,9 +43,9 @@ include:
   - sift.python3-packages.wheel
   - sift.python3-packages.yara-python
 
-sift-python3-packages:
-  test.nop:
-    - name: sift-python3-packages
+sift-python3-packages-upgrade:
+  cmd.run:
+    - name: /usr/bin/python3 -m pip install --upgrade argparse bitstring colorama geoip2 ioc_writer lxml pefile pillow pyhindsight python-dateutil python-evtx python-magic python-registry setuptools setuptools_rust six stix-validator stix virustotal-api wheel yara-python pip
     - require:
       - sls: sift.python3-packages.pip
       - sls: sift.python3-packages.argparse
@@ -34,9 +53,7 @@ sift-python3-packages:
       - sls: sift.python3-packages.colorama
       - sls: sift.python3-packages.geoip2
       - sls: sift.python3-packages.ioc_writer
-      - sls: sift.python3-packages.keyrings-alt
       - sls: sift.python3-packages.lxml
-      - sls: sift.python3-packages.machinae
       - sls: sift.python3-packages.pefile
       - sls: sift.python3-packages.pillow
       - sls: sift.python3-packages.pyhindsight
@@ -52,3 +69,4 @@ sift-python3-packages:
       - sls: sift.python3-packages.virustotal-api
       - sls: sift.python3-packages.wheel
       - sls: sift.python3-packages.yara-python
+

--- a/sift/python3-packages/virustotal-api.sls
+++ b/sift/python3-packages/virustotal-api.sls
@@ -1,10 +1,9 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
 
 sift-python3-packages-virustotal-api:
   pip.installed:
     - name: virustotal-api
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip

--- a/sift/python3-packages/wheel.sls
+++ b/sift/python3-packages/wheel.sls
@@ -1,10 +1,9 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
 
 sift-python3-packages-wheel:
   pip.installed:
     - name: wheel
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip

--- a/sift/python3-packages/yara-python.sls
+++ b/sift/python3-packages/yara-python.sls
@@ -1,10 +1,9 @@
 include:
-  - sift.packages.python3-pip
+  - sift.python3-packages.pip
 
 sift-python3-packages-yara-python:
   pip.installed:
     - name: yara-python
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: sift.packages.python3-pip
+      - sls: sift.python3-packages.pip


### PR DESCRIPTION
There have been a lot of changes in pip over the last few months, some of which cause salt to break with `upgrade: True` [as seen here](https://github.com/saltstack/salt/issues/59100), and now some packages which require cryptography need a newer version of pip along with setuptools_rust to install. 

This pull request first upgrades pip to 21.0.1 in both Bionic and Focal, then installs all the python3 packages, then runs a state called `upgrade.sls` which does a manual upgrade to all python3 packages which previously had `upgrade: True`. It also includes setuptools_rust for pyhindsight, which requires a newer version of pip. Version 21.0.1 of pip is a stable version of pip which accomplishes all tasks on both supported versions of Ubuntu.

The `pip.sls` state accomplishes the pip upgrade and pins the version to 21.0.1, so all of the python3 states needed to be updated to include/require sift.python3-packages.pip vice sift.packages.python3-pip. 

This change has been tested in docker and VM environments, on both fresh installs and upgrades.
