### PR TITLE
Fix for SSH Issue 510

### DIFF
--- a/sift/config/user/ssh.sls
+++ b/sift/config/user/ssh.sls
@@ -19,3 +19,17 @@ sift-config-user-ssh-config-gssapi:
     - append_if_not_found: True
     - require:
       - file: sift-config-user-ssh-config
+
+sift-config-user-ssh-permissions:
+  file.directory:
+    - name: {{ home }}/.ssh
+    - user: {{ user }}
+    - group: {{ user }}
+    - dir_mode: 755
+    - file_mode: 755
+    - recurse:
+      - user
+      - group
+      - mode
+
+  

--- a/sift/config/user/user.sls
+++ b/sift/config/user/user.sls
@@ -13,5 +13,5 @@ sift-user-{{ user }}:
     - shell: /bin/bash
     - home: /home/{{ user }}
     - password: $6$7n5jpcUZ$oh6U9W9mWKbtgIcY8y4buQZR3XMBOU2xUi4xGH9kvcB9o4IIsFLZ/.ffhqqVI0gkVchcJf3RSLxQhpgwXgmBR/
-    - gid_from_name: True
+    - usergroup: True
 {%- endif %}


### PR DESCRIPTION
This fixes the .ssh issue listed in SIFT Issue [#510](https://github.com/teamdfir/sift/issues/510). Also, in the latest salt 3001, the "gid_from_name" is no longer a valid option, resulting in the following error:

`salt.exceptions.SaltInvocationError: 'gid_from_name' is an invalid keyword argument for 'user.present'`

Updated this to be `usergroup: True` to fix this issue.