### PR TITLE
Fix python2 pip install

### DIFF
--- a/sift/packages/python2-pip.sls
+++ b/sift/packages/python2-pip.sls
@@ -12,7 +12,7 @@ sift-package-python2-pip:
 {%- elif grains['oscodename'] == "focal" %}
 sift-package-python2-pip-install-script:
   cmd.run:
-    - name: curl -o /tmp/get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py 
+    - name: curl -o /tmp/get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py 
     - unless: which pip2
     - require:
       - sls: sift.packages.python2


### PR DESCRIPTION
The URL for pulling the python2 get-pip.py script has changed. This pull modifies the URL to download from the proper location.