### PR TITLE
Temporary fix for pefile issue

### DIFF
--- a/sift/python-packages/pefile.sls
+++ b/sift/python-packages/pefile.sls
@@ -1,11 +1,13 @@
 include:
   - sift.packages.python3-pip
   - sift.packages.python2-pip
+  - sift.packages.git
 
 sift-python-packages-pefile:
   pip.installed:
-    - name: pefile
+    - name: git+https://github.com/digitalsleuth/pefile.git
     - bin_env: /usr/bin/python2
     - upgrade: True
     - require:
       - sls: sift.packages.python2-pip
+      - sls: sift.packages.git


### PR DESCRIPTION
An issue with pefile [here](https://github.com/erocarrera/pefile/issues/318) causes an error during install. A pull request has been submitted with the original source to rectify this issue. However on the off chance this fix isn't applied in a timely manner, I have created a fix for the issue and modified the salt state for pefile to accommodate for the fix.

Once the author fixes the issue with pefile and the error no longer exists, this salt state can be returned to normal.