### PR TITLE
Restore pefile

### DIFF
--- a/sift/python-packages/pefile.sls
+++ b/sift/python-packages/pefile.sls
@@ -1,13 +1,11 @@
 include:
   - sift.packages.python3-pip
   - sift.packages.python2-pip
-  - sift.packages.git
 
 sift-python-packages-pefile:
   pip.installed:
-    - name: git+https://github.com/digitalsleuth/pefile.git
+    - name: pefile
     - bin_env: /usr/bin/python2
     - upgrade: True
     - require:
       - sls: sift.packages.python2-pip
-      - sls: sift.packages.git


### PR DESCRIPTION
The author of pefile has decided not to support python2 any further, and has yanked the 2021.5.13 release which was causing the python2 errors. Now, installing pefile via python2 pip reverts to the 2019 version of pefile, which is fully python2 compliant.

Since there is no longer need for redirection to the python2-fixed 2021.5.13 version, I've restored the salt state to its original condition.