### PR TITLE
Re-add INDXParse to init

### DIFF
--- a/sift/python-packages/indxparse.sls
+++ b/sift/python-packages/indxparse.sls
@@ -26,6 +26,6 @@ sift-python-packages-indxparse:
 sift-python-packages-indxparse-shebang:
   file.prepend:
     - name: /usr/local/bin/INDXParse.py
-    - text: '#!/usr/bin/env python'
+    - text: '#!/usr/bin/env python2'
     - watch:
       - pip: sift-python-packages-indxparse

--- a/sift/python-packages/indxparse.sls
+++ b/sift/python-packages/indxparse.sls
@@ -8,6 +8,7 @@ include:
   - sift.packages.pkg-config
   - sift.packages.python3-pip
   - sift.packages.python2-pip
+  - sift.packages.python2-dev
   - sift.packages.python-wxgtk3
 
 sift-python-packages-indxparse:
@@ -20,6 +21,7 @@ sift-python-packages-indxparse:
       - sls: sift.packages.g++
       - sls: sift.packages.pkg-config
       - sls: sift.packages.python2-pip
+      - sls: sift.packages.python2-dev
       - sls: sift.packages.libfuse-dev
       - sls: sift.packages.python-wxgtk3
 

--- a/sift/python-packages/init.sls
+++ b/sift/python-packages/init.sls
@@ -8,6 +8,7 @@ include:
   - sift.python-packages.distorm3
   - sift.python-packages.docopt
   - sift.python-packages.geoip2
+  - sift.python-packages.indxparse
   - sift.python-packages.ioc_writer
   - sift.python-packages.lxml
   - sift.python-packages.ntdsxtract
@@ -40,6 +41,7 @@ sift-python-packages:
       - sls: sift.python-packages.distorm3
       - sls: sift.python-packages.docopt
       - sls: sift.python-packages.geoip2
+      - sls: sift.python-packages.indxparse
       - sls: sift.python-packages.ioc_writer
       - sls: sift.python-packages.lxml
       - sls: sift.python-packages.ntdsxtract


### PR DESCRIPTION
Fixes issue [537](https://github.com/teamdfir/sift/issues/537) where INDXParse is missing. Turns out, it was missing from the init state in python-packages. Also rectified the prepend for focal to use `/usr/bin/env python2` rather than just `python`.

Resolves https://github.com/teamdfir/sift/issues/537