### PR TITLE
Add volatility3 for issue #557

### DIFF
--- a/sift/python3-packages/init.sls
+++ b/sift/python3-packages/init.sls
@@ -22,6 +22,7 @@ include:
   - sift.python3-packages.stix-validator
   - sift.python3-packages.stix
   - sift.python3-packages.virustotal-api
+  - sift.python3-packages.volatility3
   - sift.python3-packages.wheel
   - sift.python3-packages.yara-python
 
@@ -52,5 +53,6 @@ sift-python3-packages:
       - sls: sift.python3-packages.stix-validator
       - sls: sift.python3-packages.stix
       - sls: sift.python3-packages.virustotal-api
+      - sls: sift.python3-packages.volatility3
       - sls: sift.python3-packages.wheel
       - sls: sift.python3-packages.yara-python

--- a/sift/python3-packages/volatility3.sls
+++ b/sift/python3-packages/volatility3.sls
@@ -1,0 +1,39 @@
+# Name: Volatility 3
+# Website: https://github.com/volatilityfoundation/volatility3
+# Description: Memory forensics tool and framework
+# Category: 
+# Author: The Volatility Foundation
+# License: Volatility Software License: https://github.com/volatilityfoundation/volatility3/blob/master/LICENSE.txt
+# Notes: Invoke using: vol3, volshell3. Before using, download symbols by following the links from https://github.com/volatilityfoundation/volatility3#symbol-tables and place them in `/usr/local/lib/python3.8/dis>
+
+include:
+  - sift.packages.git
+  - sift.python3-packages.pefile
+  - sift.python3-packages.pip
+
+sift-python3-packages-volatility3:
+  pip.installed:
+    - name: git+https://github.com/volatilityfoundation/volatility3.git
+    - bin_env: /usr/bin/python3
+    - require:
+      - sls: sift.packages.git
+      - sls: sift.python3-packages.pip
+      - sls: sift.python3-packages.pefile
+
+sift-python3-packages-volatility-rename-vol:
+  file.rename:
+    - name: /usr/local/bin/vol3
+    - source: /usr/local/bin/vol
+    - force: true
+    - makedirs: True
+    - watch:
+      - pip: sift-python3-packages-volatility3
+
+sift-python3-packages-volatility-rename-volshell:
+  file.rename:
+    - name: /usr/local/bin/volshell3
+    - source: /usr/local/bin/volshell
+    - force: true
+    - makedirs: True
+    - watch:
+      - pip: sift-python3-packages-volatility3


### PR DESCRIPTION
In support of [Issue #557](https://github.com/teamdfir/sift/issues/557), adding volatility3. 
It's worth noting that volatility 3 will require the appropriate symbols to function, and this state / change will not download these files. Users will be required to download them separately.