### PR TITLE
Fix Issue #559

### DIFF
--- a/sift/python3-packages/init.sls
+++ b/sift/python3-packages/init.sls
@@ -24,6 +24,7 @@ include:
   - sift.python3-packages.virustotal-api
   - sift.python3-packages.wheel
   - sift.python3-packages.yara-python
+  - sift.python3-packages.jinja2
 
 sift-python3-packages:
   test.nop:
@@ -54,3 +55,4 @@ sift-python3-packages:
       - sls: sift.python3-packages.virustotal-api
       - sls: sift.python3-packages.wheel
       - sls: sift.python3-packages.yara-python
+      - sls: sift.python3-packages.jinja2

--- a/sift/python3-packages/jinja2.sls
+++ b/sift/python3-packages/jinja2.sls
@@ -1,0 +1,8 @@
+include:
+  - sift.python3-packages.pip
+
+jinja2==3.0.3:
+  pip.installed:
+    - bin_env: /usr/bin/python3
+    - require:
+      - sls: sift.python3-packages.pip


### PR DESCRIPTION
This issue is caused by versions of Jinja2 > 3.1 changing the layout of required packages. Changes to fix this are forthcoming from Salt ([see here](https://github.com/saltstack/salt/pull/61856)), but in the meantime this still breaks Saltstack on all hosts.
Temporary fix is to pin the version of Jinja2 to 3.0.3 (as in this PR). 

This will ensure the issue doesn't persist when Jinja is upgraded during installation.