### PR TITLE
Fix KDE Wallet issue

### DIFF
--- a/sift/python3-packages/init.sls
+++ b/sift/python3-packages/init.sls
@@ -1,5 +1,6 @@
 include:
   - sift.python3-packages.pip
+  - sift.python3-packages.python3-keyring
   - sift.python3-packages.argparse
   - sift.python3-packages.bitstring
   - sift.python3-packages.colorama
@@ -30,6 +31,7 @@ sift-python3-packages:
     - name: sift-python3-packages
     - require:
       - sls: sift.python3-packages.pip
+      - sls: sift.python3-packages.python3-keyring
       - sls: sift.python3-packages.argparse
       - sls: sift.python3-packages.bitstring
       - sls: sift.python3-packages.colorama

--- a/sift/python3-packages/python3-keyring.sls
+++ b/sift/python3-packages/python3-keyring.sls
@@ -1,0 +1,4 @@
+export-keyring-backend-setenv:
+  environ.setenv:
+    - name: PYTHON_KEYRING_BACKEND
+    - value: keyring.backends.null.Keyring


### PR DESCRIPTION
This resolves an issue with the KDE Wallet window popping up during python3 package installs. It will change a local environment variable to indicate that the keyring is set to null during the installation, but does not persist so it will not impact existing wallets.
