### PR TITLE
Fix issue with setuptools causing crash

### DIFF
--- a/sift/python3-packages/setuptools.sls
+++ b/sift/python3-packages/setuptools.sls
@@ -3,7 +3,7 @@ include:
 
 sift-python3-packages-setuptools:
   pip.installed:
-    - name: setuptools
+    - name: 'setuptools<66.0.0'
     - bin_env: /usr/bin/python3
     - require:
       - sls: sift.python3-packages.pip


### PR DESCRIPTION
Setuptools causes a crash during regular apt updates / upgrades because the semantic versioning of packages doesn't fit standard now enforced by setuptools above 66. Issue referenced [here](https://github.com/pypa/setuptools/issues/3772).

This PR will pin setuptools to any version under 66 until the issue is resolved.