### PR TITLE
Add Zimmerman Tools

### DIFF
--- a/sift/packages/dotnet.sls
+++ b/sift/packages/dotnet.sls
@@ -1,0 +1,8 @@
+include:
+  - sift.repos.microsoft
+
+dotnet6-install:
+  pkg.installed:
+    - name: dotnet-sdk-6.0
+    - require:
+      - sls: sift.repos.microsoft

--- a/sift/repos/microsoft.sls
+++ b/sift/repos/microsoft.sls
@@ -1,0 +1,17 @@
+sift-microsoft-key:
+  file.managed:
+    - name: /usr/share/keyrings/MICROSOFT.asc
+    - source: https://packages.microsoft.com/keys/microsoft.asc
+    - skip_verify: True
+    - makedirs: True
+
+microsoft:
+  pkgrepo.managed:
+    - humanname: Microsoft
+    - name: deb [arch=amd64 signed-by=/usr/share/keyrings/MICROSOFT.asc] https://packages.microsoft.com/ubuntu/{{ grains['lsb_distrib_release'] }}/prod {{ grains['lsb_distrib_codename'] }} main
+    - dist: {{ grains['lsb_distrib_codename'] }}
+    - file: /etc/apt/sources.list.d/microsoft.list
+    - refresh: True
+    - clean_file: True
+    - require:
+      - file: sift-microsoft-key

--- a/sift/scripts/init.sls
+++ b/sift/scripts/init.sls
@@ -26,6 +26,7 @@ include:
   - sift.scripts.usbdeviceforensics
   - sift.scripts.virustotal-tools
   - sift.scripts.vshot
+  - sift.scripts.zimmerman
 
 sift-scripts:
   test.nop:
@@ -58,3 +59,4 @@ sift-scripts:
       - sls: sift.scripts.usbdeviceforensics
       - sls: sift.scripts.virustotal-tools
       - sls: sift.scripts.vshot
+      - sls: sift.scripts.zimmerman

--- a/sift/scripts/zimmerman.sls
+++ b/sift/scripts/zimmerman.sls
@@ -1,0 +1,55 @@
+{%- set user = salt['pillar.get']('sift_user', 'sansforensics') -%}
+{%- set all_users = salt['user.list_users']() -%}
+{%- if user == "root" -%}
+  {%- set home = "/root" -%}
+{%- else -%}
+  {%- set home = "/home/" + user -%}
+{%- endif -%}
+
+{% set tools = ['AmcacheParser','AppCompatCacheParser','bstrings','EvtxECmd','iisGeolocate','JLECmd','LECmd','MFTECmd','RBCmd','RecentFileCacheParser','RECmd','rla','SBECmd','SQLECmd','SrumECmd','WxTCmd'] %}
+
+include:
+  - sift.packages.dotnet
+  - sift.config.user.user
+
+download-all-6.zip:
+  file.managed:
+    - name: /tmp/All_6.zip
+    - source: https://f001.backblazeb2.com/file/EricZimmermanTools/net6/All_6.zip
+    - skip_verify: True
+    - makedirs: True
+
+extract-all-6.zip:
+  archive.extracted:
+    - name: /tmp
+    - source: /tmp/All_6.zip
+    - enforce_toplevel: false
+    - watch:
+      - file: download-all-6.zip
+    - require:
+      - sls: sift.packages.dotnet
+
+{% for tool in tools %}
+extract-{{ tool }}:
+  archive.extracted:
+    - name: /opt/zimmermantools/
+    - source: /tmp/{{ tool }}.zip
+    - enforce_toplevel: false
+
+{{ tool }}-wrapper:
+  file.managed:
+    - names:
+      - /usr/local/bin/{{ tool }}
+      - /usr/local/bin/{{ tool|lower }}
+    - contents: |
+        #!/bin/bash
+        {% if tool|lower == "iisgeolocate" or tool|lower == "recmd" or tool|lower == "sqlecmd" %}
+        dotnet /opt/zimmermantools/{{ tool }}/{{ tool }}.dll ${*}
+        {% elif tool|lower == "evtxecmd" %}
+        dotnet /opt/zimmermantools/EvtxeCmd/{{ tool }}.dll ${*}
+        {% else %}
+        dotnet /opt/zimmermantools/{{ tool }}.dll ${*}
+        {% endif %}
+    - mode: 755
+    - replace: True
+{% endfor %}


### PR DESCRIPTION
As per the request in [Issue 602](https://github.com/teamdfir/sift/issues/602), this modification adds the Zimmerman Tool suite, but only those tools compatible to run in Linux. It also adds the Microsoft repo, to get the dotnet-sdk-6.0 required for the tools.