### PR TITLE
Update SIFT package state names

### DIFF
--- a/sift/packages/aeskeyfind.sls
+++ b/sift/packages/aeskeyfind.sls
@@ -6,5 +6,6 @@
 # License: Free, unknown license
 # Notes: aeskeyfind
 
-aeskeyfind:
-  pkg.installed
+sift-package-aeskeyfind:
+  pkg.installed:
+    - name: aeskeyfind

--- a/sift/packages/afflib-tools.sls
+++ b/sift/packages/afflib-tools.sls
@@ -6,5 +6,6 @@
 # License: https://github.com/sshock/AFFLIBv3/blob/master/COPYING
 # Notes: 
 
-afflib-tools:
-  pkg.installed
+sift-package-afflib-tools:
+  pkg.installed:
+    - name: afflib-tools

--- a/sift/packages/aircrack-ng.sls
+++ b/sift/packages/aircrack-ng.sls
@@ -6,5 +6,6 @@
 # License: https://www.aircrack-ng.org/license.html
 # Notes: aircrack
 
-aircrack-ng:
-  pkg.installed
+sift-package-aircrack-ng:
+  pkg.installed:
+    - name: aircrack-ng

--- a/sift/packages/apache2.sls
+++ b/sift/packages/apache2.sls
@@ -6,5 +6,6 @@
 # License: https://www.apache.org/licenses/LICENSE-2.0
 # Notes: apache2
 
-apache2:
-  pkg.installed
+sift-package-apache2:
+  pkg.installed:
+    - name: apache2

--- a/sift/packages/apt-transport-https.sls
+++ b/sift/packages/apt-transport-https.sls
@@ -1,2 +1,3 @@
-apt-transport-https:
-  pkg.installed
+sift-package-apt-transport-https:
+  pkg.installed:
+    - name: apt-transport-https

--- a/sift/packages/arp-scan.sls
+++ b/sift/packages/arp-scan.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v3.0 (https://github.com/royhills/arp-scan/blob/master/COPYING)
 # Notes: arp-scan
 
-arp-scan:
-  pkg.installed
+sift-package-arp-scan:
+  pkg.installed:
+    - name: arp-scan

--- a/sift/packages/autopsy.sls
+++ b/sift/packages/autopsy.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v2 and Apache 2 (https://sleuthkit.org/autopsy/licenses.php)
 # Notes: 
 
-autopsy:
-  pkg.installed
+sift-package-autopsy:
+  pkg.installed:
+    - name: autopsy

--- a/sift/packages/avfs.sls
+++ b/sift/packages/avfs.sls
@@ -1,3 +1,3 @@
-sift-packages-avfs:
+sift-package-avfs:
   pkg.installed:
     - name: avfs

--- a/sift/packages/bless.sls
+++ b/sift/packages/bless.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v2.0 (https://github.com/afrantzis/bless/blob/master/COPYING)
 # Notes: bless
 
-bless:
-  pkg.installed
+sift-package-bless:
+  pkg.installed:
+    - name: bless

--- a/sift/packages/blt.sls
+++ b/sift/packages/blt.sls
@@ -6,5 +6,6 @@
 # License: BSD
 # Notes: 
 
-blt:
-  pkg.installed
+sift-package-blt:
+  pkg.installed:
+    - name: blt

--- a/sift/packages/build-essential.sls
+++ b/sift/packages/build-essential.sls
@@ -1,2 +1,3 @@
-build-essential:
-  pkg.installed
+sift-package-build-essential:
+  pkg.installed:
+    - name: build-essential

--- a/sift/packages/cabextract.sls
+++ b/sift/packages/cabextract.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License (GPL)
 # Notes: 
 
-cabextract:
-  pkg.installed
+sift-package-cabextract:
+  pkg.installed:
+    - name: cabextract

--- a/sift/packages/ccrypt.sls
+++ b/sift/packages/ccrypt.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v2 or later (http://ccrypt.sourceforge.net/#license)
 # Notes: ccrypt
 
-ccrypt:
-  pkg.installed
+sift-package-ccrypt:
+  pkg.installed:
+    - name: ccrypt

--- a/sift/packages/cifs-utils.sls
+++ b/sift/packages/cifs-utils.sls
@@ -6,5 +6,6 @@
 # License: Creative Commons License CC BY 4.0 and GNU General Public License v3.0 (https://wiki.samba.org/index.php/License and https://github.com/samba-team/samba/blob/master/COPYING)
 # Notes: 
 
-cifs-utils:
-  pkg.installed
+sift-package-cifs-utils:
+  pkg.installed:
+    - name: cifs-utils

--- a/sift/packages/clamav.sls
+++ b/sift/packages/clamav.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License (GPL): https://www.clamav.net/about
 # Notes: clamscan, freshclam
 
-clamav:
-  pkg.installed
+sift-package-clamav:
+  pkg.installed:
+    - name: clamav

--- a/sift/packages/cmospwd.sls
+++ b/sift/packages/cmospwd.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v2
 # Notes: 
 
-cmospwd:
-  pkg.installed
+sift-package-cmospwd:
+  pkg.installed:
+    - name: cmospwd

--- a/sift/packages/cryptcat.sls
+++ b/sift/packages/cryptcat.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v2.0
 # Notes: 
 
-cryptcat:
-  pkg.installed
+sift-package-cryptcat:
+  pkg.installed:
+    - name: cryptcat

--- a/sift/packages/curl.sls
+++ b/sift/packages/curl.sls
@@ -6,5 +6,6 @@
 # License: Free, custom license: https://curl.haxx.se/docs/copyright.html
 # Notes: curl
 
-curl:
-  pkg.installed
+sift-package-curl:
+  pkg.installed:
+    - name: curl

--- a/sift/packages/dbus-x11.sls
+++ b/sift/packages/dbus-x11.sls
@@ -1,2 +1,3 @@
-dbus-x11:
-  pkg.installed
+sift-package-dbus-x11:
+  pkg.installed:
+    - name: dbus-x11

--- a/sift/packages/dc3dd.sls
+++ b/sift/packages/dc3dd.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v3 (GPL v3)
 # Notes:
 
-dc3dd:
-  pkg.installed
+sift-package-dc3dd:
+  pkg.installed:
+    - name: dc3dd

--- a/sift/packages/dcfldd.sls
+++ b/sift/packages/dcfldd.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v2 (GPL v2 https://sourceforge.net/projects/dcfldd/)
 # Notes:
 
-dcfldd:
-  pkg.installed
+sift-package-dcfldd:
+  pkg.installed:
+    - name: dcfldd

--- a/sift/packages/dconf-cli.sls
+++ b/sift/packages/dconf-cli.sls
@@ -1,2 +1,3 @@
-dconf-cli:
-  pkg.installed
+sift-package-dconf-cli:
+  pkg.installed:
+    - name: dconf-cli

--- a/sift/packages/default-jre.sls
+++ b/sift/packages/default-jre.sls
@@ -1,3 +1,3 @@
-sift-default-jre:
+sift-package-default-jre:
   pkg.installed:
     - name: default-jre

--- a/sift/packages/disktype.sls
+++ b/sift/packages/disktype.sls
@@ -1,3 +1,3 @@
-sift-packages-disktype:
+sift-package-disktype:
   pkg.installed:
     - name: disktype

--- a/sift/packages/dos2unix.sls
+++ b/sift/packages/dos2unix.sls
@@ -6,6 +6,6 @@
 # License: FreeBSD style license: https://waterlan.home.xs4all.nl/dos2unix/COPYING.txt
 # Notes: dos2unix, mac2unix, unix2dos, unix2mac
 
-dos2unix:
+sift-package-dos2unix:
   pkg.installed:
     - name: dos2unix

--- a/sift/packages/driftnet.sls
+++ b/sift/packages/driftnet.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v2 (https://github.com/deiv/driftnet/blob/master/COPYING)
 # Notes: 
 
-driftnet:
-  pkg.installed
+sift-package-driftnet:
+  pkg.installed:
+    - name: driftnet

--- a/sift/packages/dsniff.sls
+++ b/sift/packages/dsniff.sls
@@ -6,5 +6,6 @@
 # License: Free, unknown license
 # Notes:
 
-dsniff:
-  pkg.installed
+sift-package-dsniff:
+  pkg.installed:
+    - name: dsniff

--- a/sift/packages/e2fsprogs.sls
+++ b/sift/packages/e2fsprogs.sls
@@ -1,2 +1,3 @@
-e2fsprogs:
-  pkg.installed
+sift-package-e2fsprogs:
+  pkg.installed:
+    - name: e2fsprogs

--- a/sift/packages/ent.sls
+++ b/sift/packages/ent.sls
@@ -6,5 +6,6 @@
 # License: Free, Public Domain
 # Notes:
 
-ent:
-  pkg.installed
+sift-package-ent:
+  pkg.installed:
+    - name: ent

--- a/sift/packages/epic5.sls
+++ b/sift/packages/epic5.sls
@@ -6,5 +6,6 @@
 # License: Free, custom license: http://www.epicsol.org/copyright
 # Notes: epic5
 
-epic5:
-  pkg.installed
+sift-package-epic5:
+  pkg.installed:
+    - name: epic5

--- a/sift/packages/etherape.sls
+++ b/sift/packages/etherape.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License (https://etherape.sourceforge.io/introduction.html#license)
 # Notes: etherape
 
-etherape:
-  pkg.installed
+sift-package-etherape:
+  pkg.installed:
+    - name: etherape

--- a/sift/packages/ettercap-graphical.sls
+++ b/sift/packages/ettercap-graphical.sls
@@ -6,5 +6,6 @@
 # License: GNU General Publice License v2 (https://github.com/Ettercap/ettercap/blob/master/LICENSE)
 # Notes: ettercap
 
-ettercap-graphical:
-  pkg.installed
+sift-package-ettercap-graphical:
+  pkg.installed:
+    - name: ettercap-graphical

--- a/sift/packages/exfat-extras_focal.sls
+++ b/sift/packages/exfat-extras_focal.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v2 (https://github.com/relan/exfat/blob/master/COPYING)
 # Notes:
 
-exfat-utils:
-  pkg.installed
+sift-package-exfat-utils:
+  pkg.installed:
+    - name: exfat-utils

--- a/sift/packages/exfat-extras_jammy.sls
+++ b/sift/packages/exfat-extras_jammy.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v2 (https://github.com/relan/exfat/blob/master/COPYING)
 # Notes:
 
-exfatprogs:
-  pkg.installed
+sift-package-exfatprogs:
+  pkg.installed:
+    - name: exfatprogs

--- a/sift/packages/exfat-fuse.sls
+++ b/sift/packages/exfat-fuse.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v2 (https://github.com/relan/exfat/blob/master/COPYING)
 # Notes: 
 
-exfat-fuse:
-  pkg.installed
+sift-package-exfat-fuse:
+  pkg.installed:
+    - name: exfat-fuse

--- a/sift/packages/exif.sls
+++ b/sift/packages/exif.sls
@@ -6,5 +6,6 @@
 # License: GNU Lesser General Public License v2.1 (https://github.com/libexif/exif/blob/master/COPYING)
 # Notes:
 
-exif:
-  pkg.installed
+sift-package-exif:
+  pkg.installed:
+    - name: exif

--- a/sift/packages/extundelete.sls
+++ b/sift/packages/extundelete.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v2
 # Notes:
 
-extundelete:
-  pkg.installed
+sift-package-extundelete:
+  pkg.installed:
+    - name: extundelete

--- a/sift/packages/fdupes.sls
+++ b/sift/packages/fdupes.sls
@@ -6,5 +6,6 @@
 # License: Copyright (c) 1999-2019 Adrian Lopez (https://github.com/adrianlopezroche/fdupes/blob/master/README)
 # Notes: fdupes
 
-fdupes:
-  pkg.installed
+sift-package-fdupes:
+  pkg.installed:
+    - name: fdupes

--- a/sift/packages/feh.sls
+++ b/sift/packages/feh.sls
@@ -6,5 +6,6 @@
 # License: Free, custom license: https://git.finalrewind.org/feh/plain/COPYING
 # Notes: 
 
-feh:
-  pkg.installed
+sift-package-feh:
+  pkg.installed:
+    - name: feh

--- a/sift/packages/flasm.sls
+++ b/sift/packages/flasm.sls
@@ -8,8 +8,9 @@
 
 {% if grains['oscodename'] != "jammy" %}
 
-flasm:
-  pkg.installed
+sift-package-flasm:
+  pkg.installed:
+    - name: flasm
 
 {% else %}
 

--- a/sift/packages/flex.sls
+++ b/sift/packages/flex.sls
@@ -6,5 +6,6 @@
 # License: BSD License (https://github.com/westes/flex/blob/master/COPYING)
 # Notes: flex
 
-flex:
-  pkg.installed
+sift-package-flex:
+  pkg.installed:
+    - name: flex

--- a/sift/packages/foremost.sls
+++ b/sift/packages/foremost.sls
@@ -6,5 +6,6 @@
 # License: Public Domain
 # Notes: 
 
-foremost:
-  pkg.installed
+sift-package-foremost:
+  pkg.installed:
+    - name: foremost

--- a/sift/packages/g++.sls
+++ b/sift/packages/g++.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v2
 # Notes: g++
 
-g++:
-  pkg.installed
+sift-package-g++:
+  pkg.installed:
+    - name: g++

--- a/sift/packages/gawk.sls
+++ b/sift/packages/gawk.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v3
 # Notes: gawk
 
-gawk:
-  pkg.installed
+sift-package-gawk:
+  pkg.installed:
+    - name: gawk

--- a/sift/packages/gcc.sls
+++ b/sift/packages/gcc.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v2
 # Notes: 
 
-gcc:
-  pkg.installed
+sift-package-gcc:
+  pkg.installed:
+    - name: gcc

--- a/sift/packages/gdb.sls
+++ b/sift/packages/gdb.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License (GPL): https://www.sourceware.org/gdb/download/onlinedocs/gdb.html#Summary
 # Notes: 
 
-gdb:
-  pkg.installed
+sift-package-gdb:
+  pkg.installed:
+    - name: gdb

--- a/sift/packages/gddrescue.sls
+++ b/sift/packages/gddrescue.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v2 and up
 # Notes: 
 
-gddrescue:
-  pkg.installed
+sift-package-gddrescue:
+  pkg.installed:
+    - name: gddrescue

--- a/sift/packages/ghex.sls
+++ b/sift/packages/ghex.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License (https://wiki.gnome.org/Apps/Ghex)
 # Notes: ghex
 
-ghex:
-  pkg.installed
+sift-package-ghex:
+  pkg.installed:
+    - name: ghex

--- a/sift/packages/git.sls
+++ b/sift/packages/git.sls
@@ -1,2 +1,3 @@
-git:
-  pkg.installed
+sift-package-git:
+  pkg.installed:
+    - name: git

--- a/sift/packages/graphviz.sls
+++ b/sift/packages/graphviz.sls
@@ -6,5 +6,6 @@
 # License: Common Public License Version 1.0 (https://graphviz.org/license/)
 # Notes: 
 
-graphviz:
-  pkg.installed
+sift-package-graphviz:
+  pkg.installed:
+    - name: graphviz

--- a/sift/packages/gthumb.sls
+++ b/sift/packages/gthumb.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v3 (https://wiki.gnome.org/Apps/Gthumb)
 # Notes: 
 
-gthumb:
-  pkg.installed
+sift-package-gthumb:
+  pkg.installed:
+    - name: gthumb

--- a/sift/packages/gzrt.sls
+++ b/sift/packages/gzrt.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License 
 # Notes: gzrecover
 
-gzrt:
-  pkg.installed
+sift-package-gzrt:
+  pkg.installed:
+    - name: gzrt

--- a/sift/packages/hexedit.sls
+++ b/sift/packages/hexedit.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v2 (https://github.com/pixel/hexedit/blob/master/COPYING)
 # Notes: hexedit
 
-hexedit:
-  pkg.installed
+sift-package-hexedit:
+  pkg.installed:
+    - name: hexedit

--- a/sift/packages/htop.sls
+++ b/sift/packages/htop.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v2 (https://github.com/htop-dev/htop/blob/master/COPYING)
 # Notes: htop
 
-htop:
-  pkg.installed
+sift-package-htop:
+  pkg.installed:
+    - name: htop

--- a/sift/packages/hydra-gtk.sls
+++ b/sift/packages/hydra-gtk.sls
@@ -6,5 +6,6 @@
 # License: GNU General Public License v2 (https://github.com/vanhauser-thc/thc-hydra/blob/master/hydra-gtk/COPYING)
 # Notes: 
 
-hydra-gtk:
-  pkg.installed
+sift-package-hydra-gtk:
+  pkg.installed:
+    - name: hydra-gtk

--- a/sift/packages/hydra.sls
+++ b/sift/packages/hydra.sls
@@ -6,5 +6,6 @@
 # License: GNU Affero General Public License (https://github.com/vanhauser-thc/thc-hydra/blob/master/LICENSE) 
 # Notes: hydra
 
-hydra:
-  pkg.installed
+sift-package-hydra:
+  pkg.installed:
+    - name: hydra

--- a/sift/packages/init.sls
+++ b/sift/packages/init.sls
@@ -142,7 +142,6 @@ include:
   - sift.packages.plaso-tools
   - sift.packages.powershell
   - sift.packages.pv
-  - sift.packages.python-flowgrep
   - sift.packages.python3
   - sift.packages.python3-dev
   - sift.packages.python3-dfvfs
@@ -351,7 +350,6 @@ sift-packages:
       - sls: sift.packages.plaso-tools
       - sls: sift.packages.powershell
       - sls: sift.packages.pv
-      - sls: sift.packages.python-flowgrep
       - sls: sift.packages.python3
       - sls: sift.packages.python3-dev
       - sls: sift.packages.python3-dfvfs

--- a/sift/packages/jq.sls
+++ b/sift/packages/jq.sls
@@ -1,3 +1,3 @@
-jq:
+sift-package-jq:
   pkg.installed:
     - name: jq

--- a/sift/packages/kdiff3.sls
+++ b/sift/packages/kdiff3.sls
@@ -1,2 +1,3 @@
-kdiff3:
-  pkg.installed
+sift-package-kdiff3:
+  pkg.installed:
+    - name: kdiff3

--- a/sift/packages/knocker.sls
+++ b/sift/packages/knocker.sls
@@ -1,7 +1,8 @@
 {% if grains['oscodename'] != "jammy" %}
 
-knocker:
-  pkg.installed
+sift-package-knocker:
+  pkg.installed:
+    - name: knocker
 
 {% else %}
 

--- a/sift/packages/kpartx.sls
+++ b/sift/packages/kpartx.sls
@@ -1,2 +1,3 @@
-kpartx:
-  pkg.installed
+sift-package-kpartx:
+  pkg.installed:
+    - name: kpartx

--- a/sift/packages/lft.sls
+++ b/sift/packages/lft.sls
@@ -1,2 +1,3 @@
-lft:
-  pkg.installed
+sift-package-lft:
+  pkg.installed:
+    - name: lft

--- a/sift/packages/libafflib-dev.sls
+++ b/sift/packages/libafflib-dev.sls
@@ -1,2 +1,3 @@
-libafflib-dev:
-  pkg.installed
+sift-package-libafflib-dev:
+  pkg.installed:
+    - name: libafflib-dev

--- a/sift/packages/libafflib.sls
+++ b/sift/packages/libafflib.sls
@@ -1,3 +1,3 @@
-libafflib:
+sift-package-libafflib:
   pkg.installed:
     - name: libafflib0v5

--- a/sift/packages/libbcprov-java.sls
+++ b/sift/packages/libbcprov-java.sls
@@ -1,3 +1,3 @@
-sift-libbcprov-java:
+sift-package-libbcprov-java:
   pkg.installed:
     - name: libbcprov-java

--- a/sift/packages/libbde-tools.sls
+++ b/sift/packages/libbde-tools.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.gift
 
-libbde-tools:
+sift-package-libbde-tools:
   pkg.installed:
     - name: libbde-tools
     - require:

--- a/sift/packages/libbde.sls
+++ b/sift/packages/libbde.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.gift
   
-libbde:
+sift-package-libbde:
   pkg.installed:
     - name: libbde
     - require:

--- a/sift/packages/libcommons-lang3-java.sls
+++ b/sift/packages/libcommons-lang3-java.sls
@@ -1,3 +1,3 @@
-sift-libcommons-lang3-java:
+sift-package-libcommons-lang3-java:
   pkg.installed:
     - name: libcommons-lang3-java

--- a/sift/packages/libevt-tools.sls
+++ b/sift/packages/libevt-tools.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.gift
 
-libevt-tools:
+sift-package-libevt-tools:
   pkg.installed:
     - name: libevt-tools
     - require:

--- a/sift/packages/libevt.sls
+++ b/sift/packages/libevt.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.gift
 
-libevt:
+sift-package-libevt:
   pkg.installed:
     - name: libevt
     - require:

--- a/sift/packages/libevtx-tools.sls
+++ b/sift/packages/libevtx-tools.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.gift
 
-libevtx-tools:
+sift-package-libevtx-tools:
   pkg.installed:
     - name: libevtx-tools
     - require:

--- a/sift/packages/libevtx.sls
+++ b/sift/packages/libevtx.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.gift
 
-libevtx:
+sift-package-libevtx:
   pkg.installed:
     - name: libevtx
     - require:

--- a/sift/packages/libewf-dev.sls
+++ b/sift/packages/libewf-dev.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.gift
 
-libewf-dev:
+sift-package-libewf-dev:
   pkg.installed:
     - name: libewf-dev
     - require:

--- a/sift/packages/libewf-python3.sls
+++ b/sift/packages/libewf-python3.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.gift
 
-libewf-python:
+sift-package-libewf-python:
   pkg.installed:
     - name: libewf-python3
     - require:

--- a/sift/packages/libewf-tools.sls
+++ b/sift/packages/libewf-tools.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.gift
 
-libewf-tools:
+sift-package-libewf-tools:
   pkg.installed:
     - name: libewf-tools
     - require:

--- a/sift/packages/libewf.sls
+++ b/sift/packages/libewf.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.gift
 
-libewf:
+sift-package-libewf:
   pkg.installed:
     - name: libewf
     - require:

--- a/sift/packages/libext2fs2.sls
+++ b/sift/packages/libext2fs2.sls
@@ -1,2 +1,3 @@
-libext2fs2:
-  pkg.installed
+sift-package-libext2fs2:
+  pkg.installed:
+    - name: libext2fs2

--- a/sift/packages/libffi-dev.sls
+++ b/sift/packages/libffi-dev.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.gift
 
-libffi-dev:
+sift-package-libffi-dev:
   pkg.installed:
     - name: libffi-dev
     - require:

--- a/sift/packages/libfuse-dev.sls
+++ b/sift/packages/libfuse-dev.sls
@@ -1,2 +1,3 @@
-libfuse-dev:
-  pkg.installed
+sift-package-libfuse-dev:
+  pkg.installed:
+    - name: libfuse-dev

--- a/sift/packages/libfvde-tools.sls
+++ b/sift/packages/libfvde-tools.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.gift
 
-libfvde-tools:
+sift-package-libfvde-tools:
   pkg.installed:
     - name: libfvde-tools
     - require:

--- a/sift/packages/libfvde.sls
+++ b/sift/packages/libfvde.sls
@@ -1,7 +1,8 @@
 include:
   - sift.repos.gift
 
-libfvde:
+sift-package-libfvde:
   pkg.installed:
+    - name: libfvde
     - require:
       - pkgrepo: gift-repo

--- a/sift/packages/libglib2-bin.sls
+++ b/sift/packages/libglib2-bin.sls
@@ -1,2 +1,3 @@
-libglib2.0-bin:
-  pkg.installed
+sift-package-libglib2.0-bin:
+  pkg.installed:
+    - name: libglib2.0-bin

--- a/sift/packages/libicu.sls
+++ b/sift/packages/libicu.sls
@@ -1,7 +1,9 @@
 {% if grains['oscodename'] == 'focal' %}
-libicu66:
-  pkg.installed
+sift-package-libicu66:
+  pkg.installed:
+    - name: libicu66
 {% elif grains['oscodename'] == 'jammy' %}
-libicu70:
-  pkg.installed
+sift-package-libicu70:
+  pkg.installed:
+    - name: libicu70
 {% endif %}

--- a/sift/packages/liblightgrep.sls
+++ b/sift/packages/liblightgrep.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.sift
 
-liblightgrep:
+sift-package-liblightgrep:
   pkg.installed:
     - name: liblightgrep
     - require:

--- a/sift/packages/libmsiecf.sls
+++ b/sift/packages/libmsiecf.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.gift
 
-libmsiecf:
+sift-package-libmsiecf:
   pkg.installed:
     - name: libmsiecf
     - require:

--- a/sift/packages/libncurses.sls
+++ b/sift/packages/libncurses.sls
@@ -1,3 +1,3 @@
-libncurses:
+sift-package-libncurses5-dev:
   pkg.installed:
     - name: libncurses5-dev

--- a/sift/packages/libnet1.sls
+++ b/sift/packages/libnet1.sls
@@ -1,2 +1,3 @@
-libnet1:
-  pkg.installed
+sift-package-libnet1:
+  pkg.installed:
+    - name: libnet1

--- a/sift/packages/libparse-win32registry-perl.sls
+++ b/sift/packages/libparse-win32registry-perl.sls
@@ -1,2 +1,3 @@
-libparse-win32registry-perl:
-  pkg.installed
+sift-package-libparse-win32registry-perl:
+  pkg.installed:
+    - name: libparse-win32registry-perl

--- a/sift/packages/libpff-dev.sls
+++ b/sift/packages/libpff-dev.sls
@@ -1,2 +1,3 @@
-libpff-dev:
-  pkg.installed
+sift-package-libpff-dev:
+  pkg.installed:
+    - name: libpff-dev

--- a/sift/packages/libpff-tools.sls
+++ b/sift/packages/libpff-tools.sls
@@ -1,2 +1,0 @@
-pff-tools:
-  pkg.installed

--- a/sift/packages/libplist-utils.sls
+++ b/sift/packages/libplist-utils.sls
@@ -1,2 +1,3 @@
-libplist-utils:
-  pkg.installed
+sift-package-libplist-utils:
+  pkg.installed:
+    - name: libplist-utils

--- a/sift/packages/libssl-dev.sls
+++ b/sift/packages/libssl-dev.sls
@@ -1,2 +1,3 @@
-libssl-dev:
-  pkg.installed
+sift-package-libssl-dev:
+  pkg.installed:
+    - name: libssl-dev

--- a/sift/packages/libtext-csv-perl.sls
+++ b/sift/packages/libtext-csv-perl.sls
@@ -1,2 +1,3 @@
-libtext-csv-perl:
-  pkg.installed
+sift-package-libtext-csv-perl:
+  pkg.installed:
+    - name: libtext-csv-perl

--- a/sift/packages/libxml2-dev.sls
+++ b/sift/packages/libxml2-dev.sls
@@ -1,2 +1,3 @@
-libxml2-dev:
-  pkg.installed
+sift-package-libxml2-dev:
+  pkg.installed:
+    - name: libxml2-dev

--- a/sift/packages/libxslt-dev.sls
+++ b/sift/packages/libxslt-dev.sls
@@ -1,3 +1,3 @@
-libxslt-dev:
+sift-package-libxslt1-dev:
   pkg.installed:
     - name: libxslt1-dev

--- a/sift/packages/libyara3.sls
+++ b/sift/packages/libyara3.sls
@@ -1,2 +1,3 @@
-libyara3:
-  pkg.installed
+sift-package-libyara3:
+  pkg.installed:
+    - name: libyara3

--- a/sift/packages/magnus.sls
+++ b/sift/packages/magnus.sls
@@ -6,5 +6,6 @@
 # License: MIT License (https://github.com/stuartlangridge/magnus/blob/master/LICENSE)
 # Notes: magnus
 
-magnus:
-  pkg.installed
+sift-package-magnus:
+  pkg.installed:
+    - name: magnus

--- a/sift/packages/nbd-client.sls
+++ b/sift/packages/nbd-client.sls
@@ -1,2 +1,3 @@
-nbd-client:
-  pkg.installed
+sift-package-nbd-client:
+  pkg.installed:
+    - name: nbd-client

--- a/sift/packages/nbtscan.sls
+++ b/sift/packages/nbtscan.sls
@@ -1,2 +1,3 @@
-nbtscan:
-  pkg.installed
+sift-package-nbtscan:
+  pkg.installed:
+    - name: nbtscan

--- a/sift/packages/netcat.sls
+++ b/sift/packages/netcat.sls
@@ -1,2 +1,3 @@
-netcat:
-  pkg.installed
+sift-package-netcat:
+  pkg.installed:
+    - name: netcat

--- a/sift/packages/netpbm.sls
+++ b/sift/packages/netpbm.sls
@@ -1,2 +1,3 @@
-netpbm:
-  pkg.installed
+sift-package-netpbm:
+  pkg.installed:
+    - name: netpbm

--- a/sift/packages/netsed.sls
+++ b/sift/packages/netsed.sls
@@ -1,2 +1,3 @@
-netsed:
-  pkg.installed
+sift-package-netsed:
+  pkg.installed:
+    - name: netsed

--- a/sift/packages/netwox.sls
+++ b/sift/packages/netwox.sls
@@ -1,2 +1,3 @@
-netwox:
-  pkg.installed
+sift-package-netwox:
+  pkg.installed:
+    - name: netwox

--- a/sift/packages/nfdump.sls
+++ b/sift/packages/nfdump.sls
@@ -1,2 +1,3 @@
-nfdump:
-  pkg.installed
+sift-package-nfdump:
+  pkg.installed:
+    - name: nfdump

--- a/sift/packages/ngrep.sls
+++ b/sift/packages/ngrep.sls
@@ -1,2 +1,3 @@
-ngrep:
-  pkg.installed
+sift-package-ngrep:
+  pkg.installed:
+    - name: ngrep

--- a/sift/packages/nikto.sls
+++ b/sift/packages/nikto.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.ubuntu-multiverse
 
-sift-nikto:
+sift-package-nikto:
   pkg.installed:
     - name: nikto
     - require:

--- a/sift/packages/ntfs-3g.sls
+++ b/sift/packages/ntfs-3g.sls
@@ -1,3 +1,3 @@
-sift-packages-ntfs-3g:
+sift-package-ntfs-3g:
   pkg.installed:
     - name: ntfs-3g

--- a/sift/packages/okular.sls
+++ b/sift/packages/okular.sls
@@ -1,2 +1,3 @@
-okular:
-  pkg.installed
+sift-package-okular:
+  pkg.installed:
+    - name: okular

--- a/sift/packages/onboard.sls
+++ b/sift/packages/onboard.sls
@@ -1,2 +1,3 @@
-onboard:
-  pkg.installed
+sift-package-onboard:
+  pkg.installed:
+    - name: onboard

--- a/sift/packages/open-iscsi.sls
+++ b/sift/packages/open-iscsi.sls
@@ -1,2 +1,3 @@
-open-iscsi:
-  pkg.installed
+sift-package-open-iscsi:
+  pkg.installed:
+    - name: open-iscsi

--- a/sift/packages/openjdk.sls
+++ b/sift/packages/openjdk.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.openjdk
 
-openjdk: 
+sift-package-openjdk-8-jdk: 
   pkg.installed:
     - name: openjdk-8-jdk
     - require:

--- a/sift/packages/ophcrack-cli.sls
+++ b/sift/packages/ophcrack-cli.sls
@@ -1,2 +1,3 @@
-ophcrack-cli:
-  pkg.installed
+sift-package-ophcrack-cli:
+  pkg.installed:
+    - name: ophcrack-cli

--- a/sift/packages/ophcrack.sls
+++ b/sift/packages/ophcrack.sls
@@ -1,2 +1,3 @@
-ophcrack:
-  pkg.installed
+sift-package-ophcrack:
+  pkg.installed:
+    - name: ophcrack

--- a/sift/packages/orca.sls
+++ b/sift/packages/orca.sls
@@ -1,2 +1,3 @@
-orca:
-  pkg.installed
+sift-package-orca:
+  pkg.installed:
+    - name: orca

--- a/sift/packages/outguess.sls
+++ b/sift/packages/outguess.sls
@@ -1,2 +1,3 @@
-outguess:
-  pkg.installed
+sift-package-outguess:
+  pkg.installed:
+    - name: outguess

--- a/sift/packages/p0f.sls
+++ b/sift/packages/p0f.sls
@@ -1,2 +1,3 @@
-p0f:
-  pkg.installed
+sift-package-p0f:
+  pkg.installed:
+    - name: p0f

--- a/sift/packages/p7zip-full.sls
+++ b/sift/packages/p7zip-full.sls
@@ -1,2 +1,3 @@
-p7zip-full:
-  pkg.installed
+sift-package-p7zip-full:
+  pkg.installed:
+    - name: p7zip-full

--- a/sift/packages/patch.sls
+++ b/sift/packages/patch.sls
@@ -1,3 +1,3 @@
-sift-patch:
+sift-package-patch:
   pkg.installed:
     - name: patch

--- a/sift/packages/pdftk-java.sls
+++ b/sift/packages/pdftk-java.sls
@@ -3,7 +3,7 @@ include:
   - sift.packages.libcommons-lang3-java
   - sift.packages.libbcprov-java
 
-sift-packages-pdftk-java:
+sift-package-pdftk-java:
   pkg.installed:
     - sources: 
         - pdftk-java: http://mirrors.edge.kernel.org/ubuntu/pool/universe/p/pdftk-java/pdftk-java_3.2.2-1_all.deb

--- a/sift/packages/pev.sls
+++ b/sift/packages/pev.sls
@@ -1,2 +1,3 @@
-pev:
-  pkg.installed
+sift-package-pev:
+  pkg.installed:
+    - name: pev

--- a/sift/packages/pff-tools.sls
+++ b/sift/packages/pff-tools.sls
@@ -1,2 +1,3 @@
-pff-tools:
-  pkg.installed
+sift-package-pff-tools:
+  pkg.installed:
+    - name: pff-tools

--- a/sift/packages/phonon.sls
+++ b/sift/packages/phonon.sls
@@ -1,3 +1,3 @@
-sift-package-phonon:
+sift-package-phonon4qt5:
   pkg.installed:
     - name: phonon4qt5

--- a/sift/packages/pkg-config.sls
+++ b/sift/packages/pkg-config.sls
@@ -1,2 +1,3 @@
-pkg-config:
-  pkg.installed
+sift-package-pkg-config:
+  pkg.installed:
+    - name: pkg-config

--- a/sift/packages/plaso-data.sls
+++ b/sift/packages/plaso-data.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.gift
 
-plaso-data:
+sift-package-plaso-data:
   pkg.latest:
     - name: plaso-data
     - require:

--- a/sift/packages/plaso-tools.sls
+++ b/sift/packages/plaso-tools.sls
@@ -2,7 +2,7 @@ include:
   - sift.repos.gift
   - sift.packages.python3-plaso
 
-plaso-tools:
+sift-package-plaso-tools:
   pkg.latest:
     - name: plaso-tools
     - require:

--- a/sift/packages/powershell.sls
+++ b/sift/packages/powershell.sls
@@ -13,7 +13,7 @@ sift-powershell-source:
     - source_hash: sha256={{ hash }}
     - makedirs: True
 
-sift-powershell:
+sift-package-powershell:
   pkg.installed:
     - sources:
       - powershell: /var/cache/sift/archives/{{ filename }}

--- a/sift/packages/pst-utils.sls
+++ b/sift/packages/pst-utils.sls
@@ -1,4 +1,4 @@
 # provides: readpst
-pst-utils:
+sift-package-pst-utils:
   pkg.installed:
     - name: pst-utils

--- a/sift/packages/pv.sls
+++ b/sift/packages/pv.sls
@@ -1,2 +1,3 @@
-pv:
-  pkg.installed
+sift-package-pv:
+  pkg.installed:
+    - name: pv

--- a/sift/packages/python-flowgrep.sls
+++ b/sift/packages/python-flowgrep.sls
@@ -1,2 +1,0 @@
-sift-package-python-flowgrep:
-  test.nop

--- a/sift/packages/python2-dev.sls
+++ b/sift/packages/python2-dev.sls
@@ -1,3 +1,3 @@
-sift-packages-python2-dev:
+sift-package-python2-dev:
   pkg.installed:
     - name: python2-dev

--- a/sift/packages/python3-debian.sls
+++ b/sift/packages/python3-debian.sls
@@ -1,3 +1,4 @@
-python3-debian:
+sift-package-python3-debian:
   pkg.installed:
+    - name: python3-debian
     - reinstall: True

--- a/sift/packages/python3-pip.sls
+++ b/sift/packages/python3-pip.sls
@@ -1,7 +1,7 @@
 include:
   - sift.packages.python3
 
-sift-pacakge-python3-pip:
+sift-package-python3-pip:
   pkg.installed:
     - name: python3-pip
     - require:

--- a/sift/packages/python3-pypff.sls
+++ b/sift/packages/python3-pypff.sls
@@ -1,2 +1,3 @@
-python3-pypff:
-  pkg.installed
+sift-package-python3-pypff:
+  pkg.installed:
+    - name: python3-pypff

--- a/sift/packages/python3-pyqt5.sls
+++ b/sift/packages/python3-pyqt5.sls
@@ -1,3 +1,3 @@
-sift-package-python-pyqt:
+sift-package-python3-pyqt5:
   pkg.installed:
     - name: python3-pyqt5

--- a/sift/packages/python3-redis.sls
+++ b/sift/packages/python3-redis.sls
@@ -1,7 +1,8 @@
 include:
   - sift.repos.gift
 
-python3-redis:
+sift-package-python3-redis:
   pkg.installed:
+    - name: python3-redis
     - require:
       - sls: sift.repos.gift

--- a/sift/packages/python3-xlsxwriter.sls
+++ b/sift/packages/python3-xlsxwriter.sls
@@ -1,3 +1,3 @@
-sift-python3-xlsxwriter:
+sift-package-python3-xlsxwriter:
   pkg.installed:
     - name: python3-xlsxwriter

--- a/sift/packages/qemu-utils.sls
+++ b/sift/packages/qemu-utils.sls
@@ -1,2 +1,3 @@
-qemu-utils:
-  pkg.installed
+sift-package-qemu-utils:
+  pkg.installed:
+    - name: qemu-utils

--- a/sift/packages/qemu.sls
+++ b/sift/packages/qemu.sls
@@ -1,2 +1,3 @@
-qemu:
-  pkg.installed
+sift-package-qemu:
+  pkg.installed:
+    - name: qemu

--- a/sift/packages/radare2.sls
+++ b/sift/packages/radare2.sls
@@ -10,7 +10,7 @@ sift-package-radare2-download:
     - source_hash: sha256={{ hash }}
     - makedirs: True
 
-sift-radare2:
+sift-package-radare2:
   pkg.installed:
     - sources:
       - radare2: /var/cache/sift/archives/{{ filename }}

--- a/sift/packages/rar.sls
+++ b/sift/packages/rar.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.ubuntu-multiverse
 
-sift-rar:
+sift-package-rar:
   pkg.installed:
     - name: rar
     - require:

--- a/sift/packages/rsakeyfind.sls
+++ b/sift/packages/rsakeyfind.sls
@@ -1,2 +1,3 @@
-rsakeyfind:
-  pkg.installed
+sift-package-rsakeyfind:
+  pkg.installed:
+    - name: rsakeyfind

--- a/sift/packages/safecopy.sls
+++ b/sift/packages/safecopy.sls
@@ -1,2 +1,3 @@
-safecopy:
-  pkg.installed
+sift-package-safecopy:
+  pkg.installed:
+    - name: safecopy

--- a/sift/packages/samba.sls
+++ b/sift/packages/samba.sls
@@ -1,2 +1,3 @@
-samba:
-  pkg.installed
+sift-package-samba:
+  pkg.installed:
+    - name: samba

--- a/sift/packages/scalpel.sls
+++ b/sift/packages/scalpel.sls
@@ -1,2 +1,3 @@
-scalpel:
-  pkg.installed
+sift-package-scalpel:
+  pkg.installed:
+    - name: scalpel

--- a/sift/packages/silversearcher-ag.sls
+++ b/sift/packages/silversearcher-ag.sls
@@ -6,6 +6,6 @@
 # License: Apache License 2.0 (https://github.com/ggreer/the_silver_searcher/blob/master/LICENSE)
 # Notes: Command is 'ag'
 
-sift-pacakge-silversearcher-ag:
+sift-package-silversearcher-ag:
   pkg.installed:
     - name: silversearcher-ag

--- a/sift/packages/socat.sls
+++ b/sift/packages/socat.sls
@@ -1,2 +1,3 @@
-socat:
-  pkg.installed
+sift-package-socat:
+  pkg.installed:
+    - name: socat

--- a/sift/packages/software-properties-common.sls
+++ b/sift/packages/software-properties-common.sls
@@ -1,2 +1,3 @@
-software-properties-common:
-  pkg.installed
+sift-package-software-properties-common:
+  pkg.installed:
+    - name: software-properties-common

--- a/sift/packages/ssdeep.sls
+++ b/sift/packages/ssdeep.sls
@@ -1,2 +1,3 @@
-ssdeep:
-  pkg.installed
+sift-package-ssdeep:
+  pkg.installed:
+    - name: ssdeep

--- a/sift/packages/ssldump.sls
+++ b/sift/packages/ssldump.sls
@@ -1,2 +1,3 @@
-ssldump:
-  pkg.installed
+sift-package-ssldump:
+  pkg.installed:
+    - name: ssldump

--- a/sift/packages/sslsniff.sls
+++ b/sift/packages/sslsniff.sls
@@ -1,2 +1,3 @@
-sslsniff:
-  pkg.installed
+sift-package-sslsniff:
+  pkg.installed:
+    - name: sslsniff

--- a/sift/packages/stunnel4.sls
+++ b/sift/packages/stunnel4.sls
@@ -1,2 +1,3 @@
-stunnel4:
-  pkg.installed
+sift-package-stunnel4:
+  pkg.installed:
+    - name: stunnel4

--- a/sift/packages/tcl.sls
+++ b/sift/packages/tcl.sls
@@ -1,2 +1,3 @@
-tcl:
-  pkg.installed
+sift-package-tcl:
+  pkg.installed:
+    - name: tcl

--- a/sift/packages/tcpflow.sls
+++ b/sift/packages/tcpflow.sls
@@ -1,2 +1,3 @@
-tcpflow:
-  pkg.installed
+sift-package-tcpflow:
+  pkg.installed:
+    - name: tcpflow

--- a/sift/packages/tcpick.sls
+++ b/sift/packages/tcpick.sls
@@ -1,2 +1,3 @@
-tcpick:
-  pkg.installed
+sift-package-tcpick:
+  pkg.installed:
+    - name: tcpick

--- a/sift/packages/tcpreplay.sls
+++ b/sift/packages/tcpreplay.sls
@@ -1,2 +1,3 @@
-tcpreplay:
-  pkg.installed
+sift-package-tcpreplay:
+  pkg.installed:
+    - name: tcpreplay

--- a/sift/packages/tcpslice.sls
+++ b/sift/packages/tcpslice.sls
@@ -1,2 +1,3 @@
-tcpslice:
-  pkg.installed
+sift-package-tcpslice:
+  pkg.installed:
+    - name: tcpslice

--- a/sift/packages/tcpstat.sls
+++ b/sift/packages/tcpstat.sls
@@ -1,2 +1,3 @@
-tcpstat:
-  pkg.installed
+sift-package-tcpstat:
+  pkg.installed:
+    - name: tcpstat

--- a/sift/packages/tcptrace.sls
+++ b/sift/packages/tcptrace.sls
@@ -1,2 +1,3 @@
-tcptrace:
-  pkg.installed
+sift-package-tcptrace:
+  pkg.installed:
+    - name: tcptrace

--- a/sift/packages/tcptrack.sls
+++ b/sift/packages/tcptrack.sls
@@ -1,2 +1,3 @@
-tcptrack:
-  pkg.installed
+sift-package-tcptrack:
+  pkg.installed:
+    - name: tcptrack

--- a/sift/packages/tcpxtract.sls
+++ b/sift/packages/tcpxtract.sls
@@ -1,2 +1,3 @@
-tcpxtract:
-  pkg.installed
+sift-package-tcpxtract:
+  pkg.installed:
+    - name: tcpxtract

--- a/sift/packages/testdisk.sls
+++ b/sift/packages/testdisk.sls
@@ -1,2 +1,3 @@
-testdisk:
-  pkg.installed
+sift-package-testdisk:
+  pkg.installed:
+    - name: testdisk

--- a/sift/packages/tofrodos.sls
+++ b/sift/packages/tofrodos.sls
@@ -1,2 +1,3 @@
-tofrodos:
-  pkg.installed
+sift-package-tofrodos:
+  pkg.installed:
+    - name: tofrodos

--- a/sift/packages/transmission.sls
+++ b/sift/packages/transmission.sls
@@ -1,2 +1,3 @@
-transmission:
-  pkg.installed
+sift-package-transmission:
+  pkg.installed:
+    - name: transmission

--- a/sift/packages/unity-control-center.sls
+++ b/sift/packages/unity-control-center.sls
@@ -1,2 +1,3 @@
-unity-control-center:
-  pkg.installed
+sift-package-unity-control-center:
+  pkg.installed:
+    - name: unity-control-center

--- a/sift/packages/unrar.sls
+++ b/sift/packages/unrar.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.ubuntu-multiverse
 
-sift-unrar:
+sift-package-unrar:
   pkg.installed:
     - name: unrar
     - require:

--- a/sift/packages/upx-ucl.sls
+++ b/sift/packages/upx-ucl.sls
@@ -1,2 +1,3 @@
-upx-ucl:
-  pkg.installed
+sift-package-upx-ucl:
+  pkg.installed:
+    - name: upx-ucl

--- a/sift/packages/vbindiff.sls
+++ b/sift/packages/vbindiff.sls
@@ -1,2 +1,3 @@
-vbindiff:
-  pkg.installed
+sift-package-vbindiff:
+  pkg.installed:
+    - name: vbindiff

--- a/sift/packages/vim.sls
+++ b/sift/packages/vim.sls
@@ -1,2 +1,3 @@
-vim:
-  pkg.installed
+sift-package-vim:
+  pkg.installed:
+    - name: vim

--- a/sift/packages/virtuoso-minimal.sls
+++ b/sift/packages/virtuoso-minimal.sls
@@ -1,2 +1,3 @@
-virtuoso-minimal:
-  pkg.installed
+sift-package-virtuoso-minimal:
+  pkg.installed:
+    - name: virtuoso-minimal

--- a/sift/packages/vmfs-tools.sls
+++ b/sift/packages/vmfs-tools.sls
@@ -1,2 +1,3 @@
-vmfs-tools:
-  pkg.installed
+sift-package-vmfs-tools:
+  pkg.installed:
+    - name: vmfs-tools

--- a/sift/packages/winbind.sls
+++ b/sift/packages/winbind.sls
@@ -1,2 +1,3 @@
-winbind:
-  pkg.installed
+sift-package-winbind:
+  pkg.installed:
+    - name: winbind

--- a/sift/packages/xdot.sls
+++ b/sift/packages/xdot.sls
@@ -1,2 +1,3 @@
-xdot:
-  pkg.installed
+sift-package-xdot:
+  pkg.installed:
+    - name: xdot

--- a/sift/packages/xfsprogs.sls
+++ b/sift/packages/xfsprogs.sls
@@ -1,2 +1,3 @@
-xfsprogs:
-  pkg.installed
+sift-package-xfsprogs:
+  pkg.installed:
+    - name: xfsprogs

--- a/sift/packages/xmount.sls
+++ b/sift/packages/xmount.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.ubuntu-universe
 
-sift-packages-xmount:
+sift-package-xmount:
   pkg.latest:
     - name: xmount
     - require:

--- a/sift/packages/zenity.sls
+++ b/sift/packages/zenity.sls
@@ -1,2 +1,3 @@
-zenity:
-  pkg.installed
+sift-package-zenity:
+  pkg.installed:
+    - name: zenity


### PR DESCRIPTION
This PR updates all of the package states to reflect the `sift-package-<pkg_name>` structure to avoid issues with state ID collisions when more than one distribution of salt-states are installed.