### PR TITLE
Update m2crypto version requirement

### DIFF
--- a/sift/python-packages/m2crypto.sls
+++ b/sift/python-packages/m2crypto.sls
@@ -7,7 +7,7 @@ include:
 
 sift-python-packages-m2crypto:
   pip.installed:
-    - name: m2crypto
+    - name: m2crypto==0.40.1
     - bin_env: /usr/bin/python2
     - upgrade: True
     - require:


### PR DESCRIPTION
Due to m2crypto recently dropping support for Python 2 in version 0.41.0, the install of m2crypto to support volatility2 and vshot fails. The last version to support Py2 is 0.40.1, so in order to support volatility2 and vshot, this PR pins the version of m2crypto at 0.40.1.