### PR TITLE
Plaso reinstall

### DIFF
--- a/sift/packages/plaso-tools.sls
+++ b/sift/packages/plaso-tools.sls
@@ -9,8 +9,16 @@
 include:
   - sift.repos.gift
 
+sift-packages-plaso-reinstall:
+  pkg.removed:
+    - names:
+      - plaso-data
+      - plaso-tools
+      - plaso
+
 sift-package-plaso-tools:
   pkg.latest:
     - name: plaso-tools
     - require:
       - sls: sift.repos.gift
+      - pkg: sift-packages-plaso-reinstall

--- a/sift/packages/plaso-tools.sls
+++ b/sift/packages/plaso-tools.sls
@@ -9,7 +9,7 @@
 include:
   - sift.repos.gift
 
-sift-packages-plaso-reinstall:
+sift-package-plaso-remove:
   pkg.removed:
     - names:
       - plaso-data
@@ -21,4 +21,4 @@ sift-package-plaso-tools:
     - name: plaso-tools
     - require:
       - sls: sift.repos.gift
-      - pkg: sift-packages-plaso-reinstall
+      - pkg: sift-package-plaso-remove


### PR DESCRIPTION
To support VM's and environments which already have plaso installed with the current pyparsing issue, this state will remove the existing installation of plaso, then re-install. This will ensure that the current, broken installation gets removed and re-installed properly.