### PR TITLE
Update Zimmerman Tools installation

### DIFF
--- a/sift/packages/dotnet.sls
+++ b/sift/packages/dotnet.sls
@@ -1,0 +1,16 @@
+{% if grains['oscodename'] == "focal" %}
+include:
+  - sift.repos.microsoft
+
+dotnet6-install:
+  pkg.installed:
+    - name: dotnet-sdk-6.0
+    - require:
+      - sls: sift.repos.microsoft
+
+{% elif grains['oscodename'] == "jammy" %}
+sift-package-dotnet6:
+  pkg.installed:
+    - name: dotnet-sdk-6.0
+
+{% endif %}

--- a/sift/repos/microsoft.sls
+++ b/sift/repos/microsoft.sls
@@ -1,0 +1,17 @@
+sift-microsoft-key:
+  file.managed:
+    - name: /usr/share/keyrings/MICROSOFT.asc
+    - source: https://packages.microsoft.com/keys/microsoft.asc
+    - skip_verify: True
+    - makedirs: True
+
+microsoft:
+  pkgrepo.managed:
+    - humanname: Microsoft
+    - name: deb [arch=amd64 signed-by=/usr/share/keyrings/MICROSOFT.asc] https://packages.microsoft.com/ubuntu/{{ grains['lsb_distrib_release'] }}/prod {{ grains['lsb_distrib_codename'] }} main
+    - dist: {{ grains['lsb_distrib_codename'] }}
+    - file: /etc/apt/sources.list.d/microsoft.list
+    - refresh: True
+    - clean_file: True
+    - require:
+      - file: sift-microsoft-key

--- a/sift/scripts/init.sls
+++ b/sift/scripts/init.sls
@@ -26,6 +26,7 @@ include:
   - sift.scripts.usbdeviceforensics
   - sift.scripts.virustotal-tools
   - sift.scripts.vshot
+  - sift.scripts.zimmerman
 
 sift-scripts:
   test.nop:
@@ -58,3 +59,4 @@ sift-scripts:
       - sls: sift.scripts.usbdeviceforensics
       - sls: sift.scripts.virustotal-tools
       - sls: sift.scripts.vshot
+      - sls: sift.scripts.zimmerman

--- a/sift/scripts/zimmerman.sls
+++ b/sift/scripts/zimmerman.sls
@@ -1,0 +1,45 @@
+{%- set user = salt['pillar.get']('sift_user', 'sansforensics') -%}
+{%- set all_users = salt['user.list_users']() -%}
+{%- if user == "root" -%}
+  {%- set home = "/root" -%}
+{%- else -%}
+  {%- set home = "/home/" + user -%}
+{%- endif -%}
+
+{% set tools = ['AmcacheParser','AppCompatCacheParser','bstrings','EvtxECmd','iisGeolocate','JLECmd','LECmd','MFTECmd','RBCmd','RecentFileCacheParser','RECmd','rla','SBECmd','SQLECmd','WxTCmd'] %}
+
+include:
+  - sift.packages.dotnet
+  - sift.config.user.user
+
+{% for tool in tools %}
+download-{{ tool }}:
+  file.managed:
+    - name: /tmp/{{ tool }}.zip
+    - source: https://f001.backblazeb2.com/file/EricZimmermanTools/net6/{{ tool }}.zip
+    - skip_verify: True
+    - makedirs: True
+
+extract-{{ tool }}:
+  archive.extracted:
+    - name: /opt/zimmermantools/
+    - source: /tmp/{{ tool }}.zip
+    - enforce_toplevel: false
+
+{{ tool }}-wrapper:
+  file.managed:
+    - names:
+      - /usr/local/bin/{{ tool }}
+      - /usr/local/bin/{{ tool|lower }}
+    - contents: |
+        #!/bin/bash
+        {% if tool|lower == "iisgeolocate" or tool|lower == "recmd" or tool|lower == "sqlecmd" %}
+        dotnet /opt/zimmermantools/{{ tool }}/{{ tool }}.dll ${*}
+        {% elif tool|lower == "evtxecmd" %}
+        dotnet /opt/zimmermantools/EvtxeCmd/{{ tool }}.dll ${*}
+        {% else %}
+        dotnet /opt/zimmermantools/{{ tool }}.dll ${*}
+        {% endif %}
+    - mode: 755
+    - replace: True
+{% endfor %}


### PR DESCRIPTION
As per the previous PR, this state will allow for the installation of dotnet-sdk-6.0 on SIFT to support Zimmerman tools, however this state will now download each zip independently instead of as one group. The previous PR pulled a single zip file which no longer exists at its previous path, thus the update to this state.

It will also install dotnet based on the OS version at time of install. On Focal, the dotnet-sdk-6.0 does not exist without the support of the Microsoft repo, but it does exist on Jammy without the repo. If installing on Jammy with the repo, the installation completes but does not function as intended (see error [identified here](https://github.com/dotnet/core/issues/5746)).