### PR TITLE
Update defang with virtualenv

### DIFF
--- a/sift/python3-packages/defang.sls
+++ b/sift/python3-packages/defang.sls
@@ -1,5 +1,11 @@
-# WEBSITE: https://github.com/HurricaneLabs/machinae
-# LICENSE: MIT
+# Name: defang
+# Website: https://bitbucket.org/johannestaas/defang/src/master/
+# Description: Defangs and refangs malicious URLs
+# Category: 
+# Author: Johan Nestaas
+# License: GNU General Public License v2+ (https://bitbucket.org/johannestaas/defang/src/master/LICENSE)
+# Notes: 
+
 include:
   - sift.packages.python3-virtualenv
 

--- a/sift/python3-packages/defang.sls
+++ b/sift/python3-packages/defang.sls
@@ -1,11 +1,31 @@
 # WEBSITE: https://github.com/HurricaneLabs/machinae
 # LICENSE: MIT
 include:
-  - sift.python3-packages.pip
+  - sift.packages.python3-virtualenv
 
-sift-python3-packages-defang:
-  pip.installed:
-    - name: defang==0.5.2
-    - bin_env: /usr/bin/python3
+sift-python3-package-defang-venv:
+  virtualenv.managed:
+    - name: /opt/defang
+    - venv_bin: /usr/bin/virtualenv
+    - pip_pkgs:
+      - pip>=24.1.3
+      - setuptools>=70.0.0
+      - wheel>=0.38.4
     - require:
-      - sls: sift.python3-packages.pip
+      - sls: sift.packages.python3-virtualenv
+
+sift-python3-package-defang:
+  pip.installed:
+    - name: defang
+    - bin_env: /opt/defang/bin/python3
+    - upgrade: True
+    - require:
+      - virtualenv: sift-python3-package-defang-venv
+
+sift-python3-package-defang-symlink:
+  file.symlink:
+    - name: /usr/local/bin/defang
+    - target: /opt/defang/bin/defang
+    - makedirs: False
+    - require:
+      - pip: sift-python3-package-defang


### PR DESCRIPTION
This PR updates defang with a virtualenv and symlink vice a standard pip install. It removes sift.python3-packages.pip because it is not required with virtualenv.