### PR TITLE
Update bless for 24

### DIFF
--- a/sift/packages/bless.sls
+++ b/sift/packages/bless.sls
@@ -5,6 +5,12 @@
 # Author: Alexandros Frantzis
 # License: GNU General Public License v2.0 (https://github.com/afrantzis/bless/blob/master/COPYING)
 # Notes: bless
+# TODO: fix when package is available
 
+{% if grains['oscodename'] != 'noble' %}
 bless:
   pkg.installed
+{% else %}
+Bless is not available on Noble:
+  test.nop
+{% endif %}


### PR DESCRIPTION
`bless` is not available in Noble, so this adds a test case for the oscodename and if `noble`, then it will ignore the state and continue. Added a `TODO: fix` statement in the header as well.