### PR TITLE
Update cryptcat for 24

### DIFF
--- a/sift/packages/cryptcat.sls
+++ b/sift/packages/cryptcat.sls
@@ -5,6 +5,12 @@
 # Author: http://cryptcat.sourceforge.net/credits.php
 # License: GNU General Public License v2.0
 # Notes: 
+# TODO: fix when package available
 
+{% if grains['oscodename'] != 'noble' %}
 cryptcat:
   pkg.installed
+{% else %}
+Cryptcat is not available in Noble:
+  test.nop
+{% endif %}


### PR DESCRIPTION
Cryptcat is not in Noble, so I've added a test case and a `test.nop` as well as a TODO: fix.