### PR TITLE
Update libafflib for 24

### DIFF
--- a/sift/packages/libafflib-dev.sls
+++ b/sift/packages/libafflib-dev.sls
@@ -1,2 +1,10 @@
+# Name: AFFLIBv3
+# Website: https://github.com/sshock/AFFLIBv3
+# Description: Development file for AFFLIB
+# Category:
+# Author: Simson L. Garfinkel / Phillip Hellewell et al (https://github.com/sshock/AFFLIBv3/blob/master/AUTHORS)
+# License: Multiple Licenses (https://github.com/sshock/AFFLIBv3/blob/master/COPYING)
+# Notes:
+
 libafflib-dev:
   pkg.installed

--- a/sift/packages/libafflib.sls
+++ b/sift/packages/libafflib.sls
@@ -7,15 +7,11 @@
 # Notes:
 
 {% if grains['oscodename'] == 'jammy' %}
-
-sift-package-libafflib0v5:
-  pkg.installed:
-    - name: libafflib0v5
-
+  {% set package = 'libafflib0v5' %}
 {% elif grains['oscodename'] == 'noble' %}
-
-sift-package-libafflib0t64:
-  pkg.installed:
-    - name: libafflib0t64
-
+  {% set package = 'libafflib0t64' %}
 {% endif %}
+
+sift-package-libafflib:
+  pkg.installed:
+    - name: {{ package }}

--- a/sift/packages/libafflib.sls
+++ b/sift/packages/libafflib.sls
@@ -1,3 +1,21 @@
-libafflib:
+# Name: AFFLIBv3
+# Website: https://github.com/sshock/AFFLIBv3
+# Description: AFF is an open and extensible file format to store disk images
+# Category:
+# Author: Simson L. Garfinkel / Phillip Hellewell et al (https://github.com/sshock/AFFLIBv3/blob/master/AUTHORS)
+# License: Multiple Licenses (https://github.com/sshock/AFFLIBv3/blob/master/COPYING)
+# Notes:
+
+{% if grains['oscodename'] == 'jammy' %}
+
+sift-package-libafflib0v5:
   pkg.installed:
     - name: libafflib0v5
+
+{% elif grains['oscodename'] == 'noble' %}
+
+sift-package-libafflib0t64:
+  pkg.installed:
+    - name: libafflib0t64
+
+{% endif %}


### PR DESCRIPTION
libafflib has two different versions, one in each of noble and jammy. This PR updates the logic for testing the oscodename, and applies the new version. I've also updated the headers for both the libafflib and libafflib-dev states.