### PR TITLE
Update libext2fs2 for 24

### DIFF
--- a/sift/packages/libext2fs2.sls
+++ b/sift/packages/libext2fs2.sls
@@ -1,2 +1,21 @@
-libext2fs2:
-  pkg.installed
+# Name: libext2fs2 (e2fsprogs)
+# Website: https://e2fsprogs.sourceforge.net/
+# Description: File system utilities for use with the ext2 file system
+# Category:
+# Author: Theodore Ts'o (https://thunk.org/tytso/)
+# License: GNU General Public License v2 and GNU Library General Public License v2 (https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/tree/NOTICE)
+# Notes:
+
+{% if grains['oscodename'] == 'jammy' %}
+
+sift-package-libext2fs2:
+  pkg.installed:
+    - name: libext2fs2
+
+{% elif grains['oscodename'] == 'noble' %}
+
+sift-package-libext2fs2t64:
+  pkg.installed:
+    - name: libext2fs2t64
+
+{% endif %}

--- a/sift/packages/libext2fs2.sls
+++ b/sift/packages/libext2fs2.sls
@@ -7,15 +7,12 @@
 # Notes:
 
 {% if grains['oscodename'] == 'jammy' %}
+  {% set package = 'libext2fs2' %}
+{% elif grains['oscodename'] == 'noble' %}
+  {% set package = 'libext2fs2t64' %}
+{% endif %}
 
 sift-package-libext2fs2:
   pkg.installed:
-    - name: libext2fs2
+    - name: {{ package }}
 
-{% elif grains['oscodename'] == 'noble' %}
-
-sift-package-libext2fs2t64:
-  pkg.installed:
-    - name: libext2fs2t64
-
-{% endif %}


### PR DESCRIPTION
This PR adds a header for libext2fs2 and adds logic for testing oscodename and applying the appropriate package based on the logic.