### PR TITLE
Update libncurses for 24

### DIFF
--- a/sift/packages/libncurses.sls
+++ b/sift/packages/libncurses.sls
@@ -1,3 +1,3 @@
-libncurses:
+sift-package-libncurses:
   pkg.installed:
-    - name: libncurses5-dev
+    - name: libncurses-dev


### PR DESCRIPTION
The libncurses5-dev pkg is transitionally named that for transition to libncurses-dev in both Jammy and Noble. As such, the libncurses5-dev pkg does not exist in noble, but is named libncurses-dev (as it also is in jammy). Modified the state to reflect the proper package name.