### PR TITLE
Update libpff states for 24

### DIFF
--- a/sift/packages/libpff-dev.sls
+++ b/sift/packages/libpff-dev.sls
@@ -1,2 +1,11 @@
-libpff-dev:
-  pkg.installed
+# Name: libpff-dev
+# Website: https://github.com/libyal/libpff
+# Description: Development files for the libpff library
+# Category:
+# Author: Joachim Metz et al (https://github.com/libyal/libpff/blob/main/AUTHORS)
+# License: GNU and GNU Lesser General Public License v3 (https://github.com/libyal/libpff/blob/main/COPYING)
+# Notes:
+
+sift-package-libpff-dev:
+  pkg.installed:
+    - name: libpff-dev

--- a/sift/packages/libpff-tools.sls
+++ b/sift/packages/libpff-tools.sls
@@ -1,2 +1,0 @@
-pff-tools:
-  pkg.installed

--- a/sift/packages/libpff.sls
+++ b/sift/packages/libpff.sls
@@ -7,15 +7,12 @@
 # Notes: 
 
 {% if grains['oscodename'] == 'jammy' %}
+  {% set package = 'libpff1' %}
+{% elif grains['oscodename'] == 'noble' %}
+  {% set package = 'libpff1t64' %}
+{% endif %}
 
 sift-package-libpff1:
   pkg.installed:
-    - name: libpff1
+    - name: {{ package }}
 
-{% elif grains['oscodename'] == 'noble' %}
-
-sift-package-libpff1t64:
-  pkg.installed:
-    - name: libpff1t64
-
-{% endif %}

--- a/sift/packages/libpff.sls
+++ b/sift/packages/libpff.sls
@@ -1,2 +1,21 @@
-libpff1:
-  pkg.installed
+# Name: libpff
+# Website: https://github.com/libyal/libpff
+# Description: Library to access the Personal and Offline File Folder formats (PST / OST)
+# Category:
+# Author: Joachim Metz et al (https://github.com/libyal/libpff/blob/main/AUTHORS)
+# License: GNU and GNU Lesser General Public License v3 (https://github.com/libyal/libpff/blob/main/COPYING)
+# Notes: 
+
+{% if grains['oscodename'] == 'jammy' %}
+
+sift-package-libpff1:
+  pkg.installed:
+    - name: libpff1
+
+{% elif grains['oscodename'] == 'noble' %}
+
+sift-package-libpff1t64:
+  pkg.installed:
+    - name: libpff1t64
+
+{% endif %}

--- a/sift/packages/pff-tools.sls
+++ b/sift/packages/pff-tools.sls
@@ -1,2 +1,11 @@
-pff-tools:
-  pkg.installed
+# Name: pff-tools
+# Website: https://github.com/libyal/libpff
+# Description: Library to access the Personal and Offline File Folder formats (PST / OST)
+# Category:
+# Author: Joachim Metz et al (https://github.com/libyal/libpff/blob/main/AUTHORS)
+# License: GNU and GNU Lesser General Public License v3 (https://github.com/libyal/libpff/blob/main/COPYING)
+# Notes: pffexport, pffinfo
+
+sift-package-pff-tools:
+  pkg.installed:
+    - name: pff-tools

--- a/sift/packages/python3-pypff.sls
+++ b/sift/packages/python3-pypff.sls
@@ -1,2 +1,11 @@
-python3-pypff:
-  pkg.installed
+# Name: python3-pypff
+# Website: https://github.com/libyal/libpff
+# Description: Python3 bindings for the libpff library
+# Category:
+# Author: Joachim Metz et al (https://github.com/libyal/libpff/blob/main/AUTHORS)
+# License: GNU and GNU Lesser General Public License v3 (https://github.com/libyal/libpff/blob/main/COPYING)
+# Notes:
+
+sift-package-python3-pypff:
+  pkg.installed:
+    - name: python3-pypff


### PR DESCRIPTION
libpff1 has a different name in noble, so this PR updates the test logic for the oscodename and installs the appropriately named pkg. This PR also adds headers for the related pff states (libpff-dev, pff-tools, python3-pypff) and removes the old / unused libpff-tools state which did the same thing as the pff-tools state.