### PR TITLE
Update netcat for 24

### DIFF
--- a/sift/packages/netcat.sls
+++ b/sift/packages/netcat.sls
@@ -1,2 +1,11 @@
-netcat:
-  pkg.installed
+# Name: netcat-openbsd
+# Website: https://github.com/openbsd/src/tree/master/usr.bin/nc
+# Description: OpenBSD rewrite of the original netcat
+# Category: 
+# Author: OpenBSD (see License for individual names)
+# License: Multiple (https://git.launchpad.net/ubuntu/+source/netcat-openbsd/tree/debian/copyright)
+# Notes: nc
+
+sift-package-netcat-openbsd:
+  pkg.installed:
+    - name: netcat-openbsd


### PR DESCRIPTION
The `netcat` pkg from Jammy and Focal is actually a transitional package for `netcat-openbsd` (which is also available in Jammy under this name), and subsequently installs that pkg. Since the `netcat` package itself isn't available in Noble, and is actually now just `netcat-openbsd` (which works in both Jammy and Noble), this PR updates the state to explicitly call the package as `netcat-openbsd`.

This PR also adds a header to the state.