### PR TITLE
Update PowerShell for 24

### DIFF
--- a/sift/packages/powershell.sls
+++ b/sift/packages/powershell.sls
@@ -1,24 +1,32 @@
+# Name: PowerShell
+# Website: https://microsoft.com/powershell
+# Description: Linux package for PowerShell
+# Category:
+# Author: Microsoft
+# License: MIT License (https://github.com/PowerShell/PowerShell/blob/master/LICENSE.txt)
+# Notes:
+
 {# renovate: datasource=github-release-attachments depName=Powershell/Powershell #}
-{%- set version = "7.4.1" -%}
-{%- set hash = "625B7EE0B71147421723CB6022A41B5D8FC0D6E19DF25B1240008EE491BF6997" -%}
+{%- set version = "7.4.6" -%}
+{%- set hash = "79642721f0bc9baf07dafaab68ece1cbd822f86722492acf9b4031d41029a735" -%}
 {%- set filename = "powershell_" ~ version ~ "-1.deb_amd64.deb" -%}
 {%- set base_url = "https://github.com/Powershell/Powershell/releases/download/v" -%}
 
 include:
   - sift.packages.libicu
 
-sift-powershell-source:
+sift-package-powershell-source:
   file.managed:
     - name: /var/cache/sift/archives/{{ filename }}
     - source: "{{ base_url }}{{ version }}/{{ filename }}"
     - source_hash: sha256={{ hash }}
     - makedirs: True
 
-sift-powershell:
+sift-package-powershell:
   pkg.installed:
     - sources:
       - powershell: /var/cache/sift/archives/{{ filename }}
     - watch:
-      - file: sift-powershell-source
+      - file: sift-package-powershell-source
     - require:
       - sls: sift.packages.libicu


### PR DESCRIPTION
Previous powershell version 7.4.1 could not be installed in Noble due to it requiring a lower version of libicu than was available in Noble. This state updates the version to 7.4.6 which will install and run on Noble and the available version of libicu.

The libicu state has already been updated in #141 to reflect this requirement.