### PR TITLE
Update qemu for 24

### DIFF
--- a/sift/packages/qemu.sls
+++ b/sift/packages/qemu.sls
@@ -1,2 +1,11 @@
-qemu:
-  pkg.installed
+# Name: qemu
+# Website: https://www.qemu.org
+# Description: A generic and open source machine emulator and virtualizer
+# Category:
+# Author: Multiple (https://gitlab.com/qemu-project/qemu/-/blob/master/MAINTAINERS)
+# License: GNU General Public License v2 (https://gitlab.com/qemu-project/qemu/-/blob/master/LICENSE)
+# Notes:
+
+sift-package-qemu-system:
+  pkg.installed:
+    - name: qemu-system


### PR DESCRIPTION
The `qemu` package previously installed was a `dummy package` and not the actual qemu package:
```bash
qemu/jammy-updates,jammy-security 1:6.2+dfsg-2ubuntu6.24 amd64
  fast processor emulator, dummy package
```
It only previously installed a 14kb placeholder and not qemu.
The actual package is now called `qemu-system` and is available in both Jammy and Noble. This PR updates the package name and adds a header.