### PR TITLE
Fix an issue with imagemounter installation

### DIFF
--- a/sift/packages/file.sls
+++ b/sift/packages/file.sls
@@ -1,0 +1,3 @@
+sift-package-file:
+  pkg.installed:
+    - name: file

--- a/sift/packages/init.sls
+++ b/sift/packages/init.sls
@@ -67,7 +67,6 @@ include:
   - sift.packages.libafflib
   - sift.packages.libbcprov-java
   - sift.packages.libbde
-  - sift.packages.libbde-utils
   - sift.packages.libcommons-lang3-java
   - sift.packages.libdatetime-perl
   - sift.packages.libesedb
@@ -147,7 +146,6 @@ include:
   - sift.packages.python3-pefile
   - sift.packages.python3-pip
   - sift.packages.python3-pypff
-  - sift.packages.python3-tsk
   - sift.packages.python3-pyqt5
   - sift.packages.python3-redis
   - sift.packages.python3-tk
@@ -271,7 +269,6 @@ sift-packages:
       - sls: sift.packages.libafflib
       - sls: sift.packages.libbcprov-java
       - sls: sift.packages.libbde
-      - sls: sift.packages.libbde-utils
       - sls: sift.packages.libcommons-lang3-java
       - sls: sift.packages.libdatetime-perl
       - sls: sift.packages.libesedb
@@ -351,7 +348,6 @@ sift-packages:
       - sls: sift.packages.python3-pefile
       - sls: sift.packages.python3-pip
       - sls: sift.packages.python3-pypff
-      - sls: sift.packages.python3-tsk
       - sls: sift.packages.python3-pyqt5
       - sls: sift.packages.python3-redis
       - sls: sift.packages.python3-tk

--- a/sift/packages/libbde-tools.sls
+++ b/sift/packages/libbde-tools.sls
@@ -1,8 +1,8 @@
 include:
   - sift.repos.gift
 
-sift-package-libvshadow-tools:
+sift-package-libbde-tools:
   pkg.installed:
-    - name: libvshadow-tools
+    - name: libbde-tools
     - require:
       - sls: sift.repos.gift

--- a/sift/packages/libbde-utils.sls
+++ b/sift/packages/libbde-utils.sls
@@ -1,3 +1,0 @@
-sift-package-libbde-utils:
-  pkg.installed:
-    - name: libbde-utils

--- a/sift/packages/libbde.sls
+++ b/sift/packages/libbde.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.gift
   
-libbde:
+sift-package-libbde:
   pkg.installed:
     - name: libbde
     - require:

--- a/sift/packages/libewf-dev.sls
+++ b/sift/packages/libewf-dev.sls
@@ -1,3 +1,8 @@
+include:
+  - sift.repos.gift
+
 sift-package-libewf-dev:
   pkg.installed:
     - name: libewf-dev
+    - require:
+      - sls: sift.repos.gift

--- a/sift/packages/libewf-tools.sls
+++ b/sift/packages/libewf-tools.sls
@@ -1,7 +1,7 @@
 include:
   - sift.repos.gift
 
-libewf-tools:
+sift-package-libewf-tools:
   pkg.installed:
     - name: libewf-tools
     - require:

--- a/sift/packages/libewf2.sls
+++ b/sift/packages/libewf2.sls
@@ -1,3 +1,8 @@
-sift-package-libewf2:
+include:
+  - sift.repos.gift
+
+sift-package-libewf:
   pkg.installed:
-    - name: libewf2
+    - name: libewf
+    - require:
+      - sls: sift.repos.gift

--- a/sift/packages/libvhdi.sls
+++ b/sift/packages/libvhdi.sls
@@ -1,8 +1,8 @@
 include:
   - sift.repos.gift
 
-sift-package-libvshadow-tools:
+sift-package-libvhdi:
   pkg.installed:
-    - name: libvshadow-tools
+    - name: libvhdi
     - require:
       - sls: sift.repos.gift

--- a/sift/packages/lvm2.sls
+++ b/sift/packages/lvm2.sls
@@ -1,0 +1,3 @@
+sift-package-lvm2:
+  pkg.installed:
+    - name: lvm2

--- a/sift/packages/mdadm.sls
+++ b/sift/packages/mdadm.sls
@@ -1,0 +1,3 @@
+sift-package-mdadm:
+  pkg.installed:
+    - name: mdadm

--- a/sift/packages/python3-pytsk3.sls
+++ b/sift/packages/python3-pytsk3.sls
@@ -1,8 +1,8 @@
 include:
   - sift.repos.gift
 
-sift-package-libvshadow-tools:
+sift-package-python3-pytsk3:
   pkg.installed:
-    - name: libvshadow-tools
+    - name: python3-pytsk3
     - require:
       - sls: sift.repos.gift

--- a/sift/packages/python3-tsk.sls
+++ b/sift/packages/python3-tsk.sls
@@ -1,3 +1,6 @@
+include:
+  - sift.repos.gift
+
 sift-package-removed-pytsk3:
   pkg.removed:
     - name: pytsk3
@@ -7,3 +10,4 @@ sift-package-python3-tsk:
     - name: python3-tsk
     - require:
       - pkg: sift-package-removed-pytsk3
+      - sls: sift.repos.gift

--- a/sift/python3-packages/imagemounter.sls
+++ b/sift/python3-packages/imagemounter.sls
@@ -11,23 +11,25 @@ include:
   - sift.packages.afflib-tools
   - sift.packages.avfs
   - sift.packages.disktype
-  - sift.packages.libbde-utils
-  - sift.packages.ewf-tools
+  - sift.packages.file
+  - sift.packages.libbde
+  - sift.packages.libbde-tools
+  - sift.packages.libewf-tools
   - sift.packages.libvshadow-tools
+  - sift.packages.lvm2
+  - sift.packages.mdadm
   - sift.packages.ntfs-3g
-  - sift.packages.python3-tsk
   - sift.packages.qemu-utils
   - sift.packages.sleuthkit
   - sift.packages.testdisk
   - sift.packages.vmfs-tools
   - sift.packages.xfsprogs
-  - sift.packages.xmount
-  - sift.packages.libguestfs-tools
   - sift.packages.mtd-utils
   - sift.packages.squashfs-tools
   - sift.packages.git
   - sift.packages.build-essential
   - sift.packages.python3-dev
+  - sift.packages.python3-pytsk3
 
 sift-python3-package-imagemounter-venv:
   virtualenv.managed:
@@ -45,22 +47,24 @@ sift-python3-package-imagemounter-venv:
       - sls: sift.packages.afflib-tools
       - sls: sift.packages.avfs
       - sls: sift.packages.disktype
-      - sls: sift.packages.libbde-utils
-      - sls: sift.packages.ewf-tools
+      - sls: sift.packages.file
+      - sls: sift.packages.libbde
+      - sls: sift.packages.libbde-tools
+      - sls: sift.packages.libewf-tools
       - sls: sift.packages.libvshadow-tools
+      - sls: sift.packages.lvm2
+      - sls: sift.packages.mdadm
       - sls: sift.packages.ntfs-3g
-      - sls: sift.packages.python3-tsk
       - sls: sift.packages.qemu-utils
       - sls: sift.packages.sleuthkit
       - sls: sift.packages.testdisk
       - sls: sift.packages.vmfs-tools
       - sls: sift.packages.xfsprogs
-      - sls: sift.packages.xmount
-      - sls: sift.packages.libguestfs-tools
       - sls: sift.packages.mtd-utils
       - sls: sift.packages.squashfs-tools
       - sls: sift.packages.git
       - sls: sift.packages.python3-dev
+      - sls: sift.packages.python3-pytsk3
 
 sift-python3-package-imagemounter:
   pip.installed:

--- a/sift/python3-packages/init.sls
+++ b/sift/python3-packages/init.sls
@@ -9,7 +9,7 @@ include:
   - sift.python3-packages.geoip2
   - sift.python3-packages.hindsight
   - sift.python3-packages.ioc-writer
-###  - sift.python3-packages.imagemounter
+  - sift.python3-packages.imagemounter
   - sift.python3-packages.indxparse
   - sift.python3-packages.java-idx-parser
   - sift.python3-packages.keyrings-alt
@@ -24,9 +24,6 @@ include:
   - sift.python3-packages.python-dateutil
   - sift.python3-packages.python-evtx
   - sift.python3-packages.python-magic
-  - sift.python3-packages.setuptools
-  - sift.python3-packages.setuptools-rust
-  - sift.python3-packages.six
   - sift.python3-packages.sqlite-carver
   - sift.python3-packages.stix-validator
   - sift.python3-packages.stix
@@ -35,6 +32,9 @@ include:
   - sift.python3-packages.virustotal-api
   - sift.python3-packages.wheel
   - sift.python3-packages.yara-python
+  - sift.python3-packages.setuptools
+  - sift.python3-packages.setuptools-rust
+  - sift.python3-packages.six
 
 sift-python3-packages:
   test.nop:
@@ -50,7 +50,7 @@ sift-python3-packages:
       - sls: sift.python3-packages.geoip2
       - sls: sift.python3-packages.hindsight
       - sls: sift.python3-packages.ioc-writer
-###      - sls: sift.python3-packages.imagemounter
+      - sls: sift.python3-packages.imagemounter
       - sls: sift.python3-packages.indxparse
       - sls: sift.python3-packages.java-idx-parser
       - sls: sift.python3-packages.keyrings-alt
@@ -65,9 +65,6 @@ sift-python3-packages:
       - sls: sift.python3-packages.python-dateutil
       - sls: sift.python3-packages.python-evtx
       - sls: sift.python3-packages.python-magic
-      - sls: sift.python3-packages.setuptools
-      - sls: sift.python3-packages.setuptools-rust
-      - sls: sift.python3-packages.six
       - sls: sift.python3-packages.sqlite-carver
       - sls: sift.python3-packages.stix-validator
       - sls: sift.python3-packages.stix
@@ -76,3 +73,6 @@ sift-python3-packages:
       - sls: sift.python3-packages.virustotal-api
       - sls: sift.python3-packages.wheel
       - sls: sift.python3-packages.yara-python
+      - sls: sift.python3-packages.setuptools
+      - sls: sift.python3-packages.setuptools-rust
+      - sls: sift.python3-packages.six


### PR DESCRIPTION
This PR will fix an issue with the installation of imagemounter due to conflicts with available packages. It also updates multiple packages to use the `GIFT` repo to install these packages, as they are more up-to-date than the available versions from each distro's `APT` repository.