### PR TITLE
Update INDXParse and scripts venv packages

### DIFF
--- a/sift/python3-packages/indxparse.sls
+++ b/sift/python3-packages/indxparse.sls
@@ -34,6 +34,7 @@ sift-python3-package-indxparse-venv:
       - setuptools>=70.0.0
       - wheel>=0.38.4
       - importlib_metadata>=8.0.0
+      - packaging>=22.0.0
       - fusepy
     - require:
       - sls: sift.packages.python3-virtualenv

--- a/sift/scripts/4n6.sls
+++ b/sift/scripts/4n6.sls
@@ -35,6 +35,7 @@ sift-python3-package-4n6-scripts-venv:
       - pip>=24.1.3
       - setuptools>=70.0.0
       - wheel>=0.38.4
+      - packaging>=22.0.0
       - ijson
       - s2sphere
     - require:


### PR DESCRIPTION
The scripts state and INDXParse state fail due to an issue with packaging being less than it needs to be for the install to complete successfully in Jammy.