### PR TITLE
Fix Issue 663

### DIFF
--- a/sift/python3-packages/python-evtx.sls
+++ b/sift/python3-packages/python-evtx.sls
@@ -27,7 +27,7 @@ sift-python3-package-python-evtx-venv:
 
 sift-python3-package-python-evtx:
   pip.installed:
-    - name: git+https://github.com/williballenthin/python-evtx.git
+    - name: git+https://github.com/williballenthin/python-evtx.git@953520633f99c450253e8d7142d18e7fce03b684
     - bin_env: /opt/python-evtx/bin/python3
     - upgrade: True
     - require:


### PR DESCRIPTION
The most recent version of python-evtx (0.8.1) has introduced a `pyproject.toml` installation method vice the `setup.py` installation method. At the current time, this method does not correctly install the scripts in the appropriate location, causing them to fail on execution ([more information can be found here](https://github.com/williballenthin/python-evtx/issues/94)).

To account for this, the most recent version of python-evtx which does not have this version (0.8.0) is being used in this PR, and being pinned to that commit specifically, until such time as the installation method is updated to address the issue referenced above.