### PR TITLE
Update python-evtx to work with latest version

### DIFF
--- a/sift/python3-packages/python-evtx.sls
+++ b/sift/python3-packages/python-evtx.sls
@@ -6,7 +6,13 @@
 # License: Apache License 2.0 (https://github.com/williballenthin/python-evtx/blob/master/LICENSE.TXT)
 # Notes: evtx_dump.py, evtx_dump_chunk_slack.py, evtx_dump_json.py, evtx_eid_record_numbers.py, evtx_extract_record.py, evtx_filter_records.py, evtx_info.py, evtx_record_structure.py, evtx_structure.py, evtx_templates.py
 
-{% set files = ['evtx_dump.py','evtx_dump_chunk_slack.py','evtx_dump_json.py','evtx_eid_record_numbers.py','evtx_extract_record.py','evtx_filter_records.py','evtx_info.py','evtx_record_structure.py','evtx_structure.py','evtx_templates.py'] %}
+{% set files = ['evtx_dump','evtx_dump_chunk_slack','evtx_dump_json','evtx_eid_record_numbers','evtx_extract_record','evtx_filter_records','evtx_info','evtx_record_structure','evtx_structure','evtx_templates'] %}
+{% set commit = '1a1357accd3a75524794a6d6dcdec03c09e1660d' %}
+{% if grains['oscodename'] == 'noble' %}
+  {% set py_ver = '3.12' %}
+{% elif grains['oscodename'] == 'jammy' %}
+  {% set py_ver = '3.10' %}
+{% endif %}
 
 include:
   - sift.packages.python3-virtualenv
@@ -27,7 +33,7 @@ sift-python3-package-python-evtx-venv:
 
 sift-python3-package-python-evtx:
   pip.installed:
-    - name: git+https://github.com/williballenthin/python-evtx.git@953520633f99c450253e8d7142d18e7fce03b684
+    - name: git+https://github.com/williballenthin/python-evtx.git@{{ commit }}
     - bin_env: /opt/python-evtx/bin/python3
     - upgrade: True
     - require:
@@ -36,9 +42,9 @@ sift-python3-package-python-evtx:
 
 sift-python3-package-python-evtx-import-fix:
   file.replace:
-    - name: /opt/python-evtx/bin/evtx_eid_record_numbers.py
+    - name: /opt/python-evtx/lib/python{{ py_ver }}/site-packages/evtx_scripts/evtx_eid_record_numbers.py
     - pattern: 'from filter_records'
-    - repl: 'from evtx_filter_records'
+    - repl: 'from evtx_scripts.evtx_filter_records'
     - count: 1
     - require:
       - pip: sift-python3-package-python-evtx
@@ -46,7 +52,7 @@ sift-python3-package-python-evtx-import-fix:
 {% for file in files %}
 sift-python3-package-python-evtx-symlink-{{ file }}:
   file.symlink:
-    - name: /usr/local/bin/{{ file }}
+    - name: /usr/local/bin/{{ file }}.py
     - target: /opt/python-evtx/bin/{{ file }}
     - makedirs: False
     - require:


### PR DESCRIPTION
This PR now updates python-evtx to the latest version (0.8.1), as a recent PR merge in the origin repo now allows for the evtx scripts to be installed. As the scripts are all installed without a .py extension, this script retains the .py extension for the symlink, to ensure commands run the same as before.

Additionally, since the pypi package for 0.8.1 hasn't been updated, this PR pins the installation to the latest working commit for that version. Future releases can simply install from pypi instead of GitHub.