### PR TITLE
fix(docker): use dynamic architecture grain instead of hardcoded amd64

### DIFF
--- a/sift/repos/docker.sls
+++ b/sift/repos/docker.sls
@@ -35,7 +35,7 @@ sift-docker-repo:
         Suites: {{ grains['lsb_distrib_codename'] }}
         Components: stable
         Signed-By: /usr/share/keyrings/DOCKER-PGP-KEY.asc
-        Architectures: amd64
+        Architectures: {{ grains['osarch'] | replace('aarch64', 'arm64') }}
     - require:
       - file: sift-docker-key
       - pkgrepo: sift-remove-docker-ppa


### PR DESCRIPTION
## Problem

  The Docker apt sources file has `Architectures: amd64` hardcoded, which causes SIFT
  installation to fail silently on ARM64 systems — the repository is configured for the
   wrong architecture so `docker-ce` cannot be found.

  ## Fix

  Replace the hardcoded value with a Jinja grain lookup:
  Architectures: {{ grains['osarch'] | replace('aarch64', 'arm64') }}
  This writes the correct architecture (`amd64` or `arm64`) at install time.

  ## Tested on

  - Ubuntu 22.04 LTS ARM64 running in UTM on Apple Silicon (M-series Mac)