### PR TITLE
fix(ubuntu-universe): fix two ARM64 bugs in ports repo state

### DIFF
--- a/sift/repos/ubuntu-universe.sls
+++ b/sift/repos/ubuntu-universe.sls
@@ -6,12 +6,11 @@ sift-ubuntu-ports-repo:
 
         Types: deb
         URIs: http://ports.ubuntu.com/ubuntu-ports/
-        Suites: noble
+        Suites: {{ grains['lsb_distrib_codename'] }} {{ grains['lsb_distrib_codename'] }}-updates {{ grains['lsb_distrib_codename'] }}-security {{ grains['lsb_distrib_codename'] }}-backports
         Components: main universe restricted multiverse
         Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
         Architectures: arm64
-    - unless: 
-      - grep -q "URIs: http://ports.ubuntu.com/ubuntu-ports/" /etc/apt/sources.list.d/ubuntu.sources
+    - unless: grep -q "ubuntu-ports" /etc/apt/sources.list.d/ubuntu.sources
 {% else %}
 sift-universe-repo:
   file.replace:


### PR DESCRIPTION
## Problems

  **Bug 1 — hardcoded `Suites: noble`**
  The ubuntu-ports repository entry was hardcoded to `noble`, meaning the
  state only works on Ubuntu 24.04. On Ubuntu 22.04 (Jammy), universe packages
  couldn't be resolved, causing multiple SIFT tools to fail to install.

  **Bug 2 — YAML rendering failure in `unless` clause**
  The list form of `unless` with a grep command containing `URIs: http://...`
  causes Salt's YAML renderer to misparse the colon-space as a mapping key,
  producing a CRITICAL rendering error that skips the entire state:
  [CRITICAL] Rendering SLS 'base:sift.repos.ubuntu-universe' failed: could not find
  expected ':'

  ## Fixes

  - Replace `Suites: noble` with the `lsb_distrib_codename` grain so the correct suite
  names are used for any supported Ubuntu release
  - Flatten the `unless` list into a scalar with a simplified grep pattern, avoiding
  the YAML parsing conflict

  ## Tested on

  - Ubuntu 22.04 LTS ARM64 running in UTM on Apple Silicon (M-series Mac)