### PR TITLE
Noble security fix

### DIFF
--- a/sift/repos/ubuntu-multiverse.sls
+++ b/sift/repos/ubuntu-multiverse.sls
@@ -59,8 +59,12 @@ sift-security-repo:
       - grep -q "security.ubuntu.com" /etc/apt/sources.list.d/ubuntu.sources
 
 {% if codename == "jammy" %}
+
 sift-remove-sources-list-multiverse:
   file.absent:
     - name: /etc/apt/sources.list
+    - require:
+      - file: sift-multiverse-repo
+
 {% endif %}
 {% endif %}

--- a/sift/repos/ubuntu-multiverse.sls
+++ b/sift/repos/ubuntu-multiverse.sls
@@ -1,6 +1,6 @@
 {% set codename = grains["oscodename"] %}
 {%- if grains["osarch"] == "aarch64" or grains["osarch"] == "arm64" -%}
-sift-ubuntu-ports-repo:
+sift-ubuntu-ports-repo-multiverse:
   file.append:
     - name: /etc/apt/sources.list.d/ubuntu.sources
     - text: |
@@ -19,7 +19,8 @@ sift-ubuntu-ports-repo:
         Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
         Architectures: arm64
     - unless:
-      - grep -q "URIs: http://ports.ubuntu.com/ubuntu-ports/" /etc/apt/sources.list.d/ubuntu.sources
+      - grep -q "ubuntu-ports" /etc/apt/sources.list.d/ubuntu.sources
+      - grep -q "{{ codename }}-security" /etc/apt/sources.list.d/ubuntu.sources
 
 {% else %}
 {% if not salt['file.file_exists']('/etc/apt/sources.list.d/ubuntu.sources') %}
@@ -54,6 +55,6 @@ sift-security-repo:
         Components: main universe restricted multiverse
         Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
     - unless:
-      - grep -q "^Suites:.*{{ codename }}-security" /etc/apt/sources.list.d/ubuntu.sources
+      - grep -q "{{ codename }}-security" /etc/apt/sources.list.d/ubuntu.sources
 
 {% endif %}

--- a/sift/repos/ubuntu-multiverse.sls
+++ b/sift/repos/ubuntu-multiverse.sls
@@ -55,6 +55,5 @@ sift-security-repo:
         Components: main universe restricted multiverse
         Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
     - unless:
-      - grep -q "{{ codename }}-security" /etc/apt/sources.list.d/ubuntu.sources
-
+      - grep -q "ubuntu-ports" /etc/apt/sources.list.d/ubuntu.sources
 {% endif %}

--- a/sift/repos/ubuntu-multiverse.sls
+++ b/sift/repos/ubuntu-multiverse.sls
@@ -23,18 +23,18 @@ sift-ubuntu-ports-repo-multiverse:
       - grep -q "{{ codename }}-security" /etc/apt/sources.list.d/ubuntu.sources
 
 {% else %}
-{% if not salt['file.file_exists']('/etc/apt/sources.list.d/ubuntu.sources') %}
 sift-ubuntu-repo-multiverse:
-  file.managed:
+  file.append:
     - name: /etc/apt/sources.list.d/ubuntu.sources
-    - contents: |
+    - text: |
         Types: deb
-        URIs: http://ca.archive.ubuntu.com/ubuntu/
+        URIs: http://archive.ubuntu.com/ubuntu/
         Suites: {{ codename }} {{ codename }}-updates {{ codename }}-backports
         Components: main restricted universe multiverse
         Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
-    - mode: 644
-{% endif %}
+    - makedirs: True
+    - unless:
+      - grep -q "archive.ubuntu.com" /etc/apt/sources.list.d/ubuntu.sources
 
 sift-multiverse-repo:
   file.replace:
@@ -56,4 +56,11 @@ sift-security-repo:
         Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
     - unless:
       - grep -q "ubuntu-ports" /etc/apt/sources.list.d/ubuntu.sources
+      - grep -q "security.ubuntu.com" /etc/apt/sources.list.d/ubuntu.sources
+
+{% if codename == "jammy" %}
+sift-remove-sources-list-multiverse:
+  file.absent:
+    - name: /etc/apt/sources.list
+{% endif %}
 {% endif %}

--- a/sift/repos/ubuntu-multiverse.sls
+++ b/sift/repos/ubuntu-multiverse.sls
@@ -1,3 +1,4 @@
+{% set codename = grains["oscodename"] %}
 {%- if grains["osarch"] == "aarch64" or grains["osarch"] == "arm64" -%}
 sift-ubuntu-ports-repo:
   file.append:
@@ -6,14 +7,14 @@ sift-ubuntu-ports-repo:
 
         Types: deb
         URIs: http://ports.ubuntu.com/ubuntu-ports/
-        Suites: noble
+        Suites: {{ codename }}
         Components: main universe restricted multiverse
         Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
         Architectures: arm64
 
         Types: deb
         URIs: http://ports.ubuntu.com/ubuntu-ports/
-        Suites: noble-security
+        Suites: {{ codename }}-security
         Components: main universe restricted multiverse
         Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
         Architectures: arm64
@@ -21,6 +22,19 @@ sift-ubuntu-ports-repo:
       - grep -q "URIs: http://ports.ubuntu.com/ubuntu-ports/" /etc/apt/sources.list.d/ubuntu.sources
 
 {% else %}
+{% if not salt['file.file_exists']('/etc/apt/sources.list.d/ubuntu.sources') %}
+sift-ubuntu-repo-multiverse:
+  file.managed:
+    - name: /etc/apt/sources.list.d/ubuntu.sources
+    - contents: |
+        Types: deb
+        URIs: http://ca.archive.ubuntu.com/ubuntu/
+        Suites: {{ codename }} {{ codename }}-updates {{ codename }}-backports
+        Components: main restricted universe multiverse
+        Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+    - mode: 644
+{% endif %}
+
 sift-multiverse-repo:
   file.replace:
     - name: /etc/apt/sources.list.d/ubuntu.sources
@@ -36,10 +50,10 @@ sift-security-repo:
 
         Types: deb
         URIs: http://security.ubuntu.com/ubuntu/
-        Suites: noble-security
+        Suites: {{ codename }}-security
         Components: main universe restricted multiverse
         Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
     - unless:
-      - grep -q "^Suites:.*noble-security" /etc/apt/sources.list.d/ubuntu.sources
+      - grep -q "^Suites:.*{{ codename }}-security" /etc/apt/sources.list.d/ubuntu.sources
 
 {% endif %}

--- a/sift/repos/ubuntu-universe.sls
+++ b/sift/repos/ubuntu-universe.sls
@@ -11,21 +11,22 @@ sift-ubuntu-ports-repo-universe:
         Components: main universe restricted multiverse
         Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
         Architectures: arm64
+    - makedirs: True
     - unless:
       - grep -q "ubuntu-ports" /etc/apt/sources.list.d/ubuntu.sources
 {% else %}
-{% if not salt['file.file_exists']('/etc/apt/sources.list.d/ubuntu.sources') %}
 sift-ubuntu-repo-universe:
-  file.managed:
+  file.append:
     - name: /etc/apt/sources.list.d/ubuntu.sources
-    - contents: |
+    - text: |
         Types: deb
-        URIs: http://ca.archive.ubuntu.com/ubuntu/
+        URIs: http://archive.ubuntu.com/ubuntu/
         Suites: {{ codename }} {{ codename }}-updates {{ codename }}-backports
         Components: main restricted universe multiverse
         Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
-    - mode: 644
-{% endif %}
+    - makedirs: True
+    - unless:
+      - grep -q "archive.ubuntu.com" /etc/apt/sources.list.d/ubuntu.sources
 
 sift-universe-repo:
   file.replace:
@@ -34,5 +35,10 @@ sift-universe-repo:
     - repl: '\1\2 universe'
     - flags:
         - MULTILINE
-{%- endif %}
+{% if codename == "jammy" %}
+sift-remove-sources-list:
+  file.absent:
+    - name: /etc/apt/sources.list
+{% endif %}
+{% endif %}
 

--- a/sift/repos/ubuntu-universe.sls
+++ b/sift/repos/ubuntu-universe.sls
@@ -1,3 +1,4 @@
+{% set codename = grains["oscodename"] %}
 {%- if grains["osarch"] == "aarch64" or grains["osarch"] == "arm64" -%}
 sift-ubuntu-ports-repo:
   file.append:
@@ -6,13 +7,25 @@ sift-ubuntu-ports-repo:
 
         Types: deb
         URIs: http://ports.ubuntu.com/ubuntu-ports/
-        Suites: noble
+        Suites: {{ codename }}
         Components: main universe restricted multiverse
         Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
         Architectures: arm64
-    - unless: 
-      - grep -q "URIs: http://ports.ubuntu.com/ubuntu-ports/" /etc/apt/sources.list.d/ubuntu.sources
+    - unless: grep -q "ubuntu-ports" /etc/apt/sources.list.d/ubuntu.sources
 {% else %}
+{% if not salt['file.file_exists']('/etc/apt/sources.list.d/ubuntu.sources') %}
+sift-ubuntu-repo-universe:
+  file.managed:
+    - name: /etc/apt/sources.list.d/ubuntu.sources
+    - contents: |
+        Types: deb
+        URIs: http://ca.archive.ubuntu.com/ubuntu/
+        Suites: {{ codename }} {{ codename }}-updates {{ codename }}-backports
+        Components: main restricted universe multiverse
+        Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+    - mode: 644
+{% endif %}
+
 sift-universe-repo:
   file.replace:
     - name: /etc/apt/sources.list.d/ubuntu.sources

--- a/sift/repos/ubuntu-universe.sls
+++ b/sift/repos/ubuntu-universe.sls
@@ -35,10 +35,15 @@ sift-universe-repo:
     - repl: '\1\2 universe'
     - flags:
         - MULTILINE
+
 {% if codename == "jammy" %}
+
 sift-remove-sources-list:
   file.absent:
     - name: /etc/apt/sources.list
+    - require:
+      - file: sift-universe-repo
+
 {% endif %}
 {% endif %}
 

--- a/sift/repos/ubuntu-universe.sls
+++ b/sift/repos/ubuntu-universe.sls
@@ -1,6 +1,6 @@
 {% set codename = grains["oscodename"] %}
 {%- if grains["osarch"] == "aarch64" or grains["osarch"] == "arm64" -%}
-sift-ubuntu-ports-repo:
+sift-ubuntu-ports-repo-universe:
   file.append:
     - name: /etc/apt/sources.list.d/ubuntu.sources
     - text: |
@@ -11,7 +11,8 @@ sift-ubuntu-ports-repo:
         Components: main universe restricted multiverse
         Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
         Architectures: arm64
-    - unless: grep -q "ubuntu-ports" /etc/apt/sources.list.d/ubuntu.sources
+    - unless:
+      - grep -q "ubuntu-ports" /etc/apt/sources.list.d/ubuntu.sources
 {% else %}
 {% if not salt['file.file_exists']('/etc/apt/sources.list.d/ubuntu.sources') %}
 sift-ubuntu-repo-universe:


### PR DESCRIPTION
This PR addresses the issue #223 by removing the currently pinned `noble` codename and replacing it with the extracted codename from the OS. This will provide fixes for Jammy, and allow for future-proofing with Resolute. As Jammy is the oldest OS supported, it will also remove the `sources.list` file from Jammy in favor of the .sources file as long as the appropriate repo is enabled. The `file.absent` option is in both universe and multiverse to ensure that the states can function independently if only one of them is executed in the future.

Tested on Jammy and Noble on both amd64 and arm64 versions through several iterations with no issues.