### PR TITLE
Add missing dep for vol3

### DIFF
--- a/sift/packages/libusb-dev.sls
+++ b/sift/packages/libusb-dev.sls
@@ -1,0 +1,3 @@
+sift-package-libusb-dev:
+  pkg.installed:
+    - name: libusb-1.0-0-dev

--- a/sift/python3-packages/volatility3.sls
+++ b/sift/python3-packages/volatility3.sls
@@ -10,6 +10,8 @@
 
 include:
   - sift.packages.python3-virtualenv
+  - sift.packages.libusb-dev
+  - sift.packages.pkg-config
 
 sift-python3-package-volatility3-venv:
   virtualenv.managed:
@@ -28,6 +30,8 @@ sift-python3-package-volatility3-venv:
       - yara-x
     - require:
       - sls: sift.packages.python3-virtualenv
+      - sls: sift.packages.libusb-dev
+      - sls: sift.packages.pkg-config
 
 sift-python3-package-volatility3:
   pip.installed:


### PR DESCRIPTION
vol3's requirement leechcorepyc has a requirement of libusb-1.0-0-dev (newer libusb-dev) and pkg-config (for building). These requirements aren't installed by default in arm64 versions of jammy or noble, so I added explicit includes and requires for these in the state file.