### PR TITLE
Updates the Exiftool URL from exiftool.org to Sourceforge

### DIFF
--- a/sift/scripts/exiftool.sls
+++ b/sift/scripts/exiftool.sls
@@ -23,7 +23,7 @@ include:
 sift-exiftool-source:
   file.managed:
     - name: /var/cache/sift/archives/Image-ExifTool-{{ exiftool_version }}.tar.gz
-    - source: https://exiftool.org/Image-ExifTool-{{ exiftool_version }}.tar.gz
+    - source: https://sourceforge.net/projects/exiftool/files/Image-ExifTool-{{ exiftool_version }}.tar.gz
     - source_hash: sha256={{ ns.exiftool_sha256 }}
     - makedirs: True
 
@@ -48,6 +48,3 @@ sift-exiftool-install:
     - cwd: /usr/local/src/exiftool-{{ exiftool_version }}/Image-ExifTool-{{ exiftool_version }}/
     - include:
       - cmd: sift-exiftool-makefile
-
-
-  


### PR DESCRIPTION
A fresh deployment on 24.04 fails due to failed states which I pinpointed to Exiftool. Unlike the previous Exiftool issue, exiftool.org no longer hosts _any_ files, supposedly due to their host not being able to deal with the load. Exiftool is now hosted exclusively on SourceForge.

This pull request updates the URL. This URL works when using `wget`, which follows a redirect response provided by SourceForge, but I don't know if it will also work in the salt stack as-is. I don't know how to test it without having to create a release.