### PR TITLE
Update exiftool state

### DIFF
--- a/sift/scripts/exiftool.sls
+++ b/sift/scripts/exiftool.sls
@@ -19,17 +19,18 @@
 
 include:
   - sift.packages.build-essential
+  - sift.packages.perl
 
 sift-exiftool-source:
   file.managed:
     - name: /var/cache/sift/archives/Image-ExifTool-{{ exiftool_version }}.tar.gz
-    - source: https://exiftool.org/Image-ExifTool-{{ exiftool_version }}.tar.gz
+    - source: https://downloads.sourceforge.net/project/exiftool/Image-ExifTool-{{ exiftool_version }}.tar.gz
     - source_hash: sha256={{ ns.exiftool_sha256 }}
     - makedirs: True
 
 sift-exiftool-extracted:
   archive.extracted:
-    - name: /usr/local/src/exiftool-{{ exiftool_version }}
+    - name: /usr/local/src/exiftool
     - source: /var/cache/sift/archives/Image-ExifTool-{{ exiftool_version }}.tar.gz
     - source_hash: sha256={{ ns.exiftool_sha256 }}
     - watch:
@@ -38,16 +39,20 @@ sift-exiftool-extracted:
 sift-exiftool-makefile:
   cmd.run:
     - name: perl Makefile.PL
-    - cwd: /usr/local/src/exiftool-{{ exiftool_version }}/Image-ExifTool-{{ exiftool_version }}/
+    - cwd: /usr/local/src/exiftool/Image-ExifTool-{{ exiftool_version }}/
     - include:
       - sls: sift.packages.build-essential
+      - sls: sift.packages.perl
 
 sift-exiftool-install:
   cmd.run:
     - name: make install
-    - cwd: /usr/local/src/exiftool-{{ exiftool_version }}/Image-ExifTool-{{ exiftool_version }}/
-    - include:
+    - cwd: /usr/local/src/exiftool/Image-ExifTool-{{ exiftool_version }}/
+    - require:
       - cmd: sift-exiftool-makefile
 
-
-  
+sift-exiftool-remove-source-directory:
+  file.absent:
+    - name: /usr/local/src/exiftool
+    - require:
+      - cmd: sift-exiftool-install


### PR DESCRIPTION
This update accounts for the current redirection of pages from the exiftool.org site to the sourceforge project site. Details of the redirection can be found at the top of the exiftool.org page.