### PR TITLE
feat(scripts): add csvdt, CSV timestamp normalisation

### DIFF
--- a/sift/scripts/csvdt.sls
+++ b/sift/scripts/csvdt.sls
@@ -1,0 +1,49 @@
+# Name: csvdt
+# Website: https://github.com/YardQuit/csvdt
+# Description: Parse and normalise CSV on the command line, converting timestamps
+#              between epoch, ISO 8601 and Windows FILETIME forms and localising
+#              them to a time zone.
+# Category:
+# Author: YardQuit
+# License: GPL-3.0-or-later
+# Notes: csvdt
+#
+# Upstream publishes one statically linked musl binary for Linux, x86-64 only, so
+# this state is guarded to amd64. Drop the guard once an aarch64-unknown-linux-musl
+# asset ships. Pinned to the version's own tag rather than the rolling 'release'
+# tag: that one is rebuilt monthly against a newer tzdata, so its checksum moves.
+# The published names carry a target triple; the installed command is 'csvdt'.
+{# no leading '-' on the version tag below: it would strip the newline above and
+   splice the last comment line onto the state ID, commenting the state out. #}
+{# renovate: datasource=github-release-attachments depName=YardQuit/csvdt #}
+{% set version = "1.0.0" -%}
+{%- set hash = "a0ca7d2ebf0493394ad5aeb279aa0c4a812fae7449b976fdcb24cac4b1f7f28c" -%}
+{%- set base_url = "https://github.com/YardQuit/csvdt/releases/download" -%}
+
+sift-scripts-csvdt:
+  file.managed:
+    - name: /usr/local/bin/csvdt
+    - source: "{{ base_url }}/{{ version }}/csvdt-x86_64-unknown-linux-musl"
+    - source_hash: sha256={{ hash }}
+    - mode: 0755
+    - makedirs: True
+    - keep_source: True
+    - onlyif:
+      - fun: match.grain
+        tgt: 'osarch:amd64'
+
+sift-scripts-csvdt-mandir:
+  file.directory:
+    - name: /usr/local/share/man/man1
+    - makedirs: True
+
+# csvdt renders its own manual page from the same definitions that parse its
+# options, so the page cannot drift from the binary that answers the commands.
+# mandb is tolerated as absent -- man-db rescans the manpath without it.
+sift-scripts-csvdt-man:
+  cmd.run:
+    - name: /usr/local/bin/csvdt --generate-man > /usr/local/share/man/man1/csvdt.1 && (mandb -q || true)
+    - onchanges:
+      - file: sift-scripts-csvdt
+    - require:
+      - file: sift-scripts-csvdt-mandir

--- a/sift/scripts/init.sls
+++ b/sift/scripts/init.sls
@@ -1,6 +1,7 @@
 include:
   - sift.scripts.4n6
   - sift.scripts.amcache
+  - sift.scripts.csvdt
   - sift.scripts.cyberchef
   - sift.scripts.densityscout
   - sift.scripts.docker-compose
@@ -21,6 +22,7 @@ sift-scripts:
     - require:
       - sls: sift.scripts.4n6
       - sls: sift.scripts.amcache
+      - sls: sift.scripts.csvdt
       - sls: sift.scripts.cyberchef
       - sls: sift.scripts.densityscout
       - sls: sift.scripts.docker-compose


### PR DESCRIPTION
In support of [teamdfir/sift#684](https://github.com/teamdfir/sift/issues/684), opened at Rob Lee's request that csvdt be added to the SIFT Workstation project.

Adds csvdt, a command-line CSV parser whose subject is timestamps: it reads epoch, ISO 8601 and Windows FILETIME in a column and writes any of them back, localised to a named zone. The use it is meant for on SIFT is bringing a timeline assembled from several parsers onto one clock before the rows are correlated.

**Disclosure: I am the author of csvdt.** Happy to change any of the below, and equally happy to close this if it turns out not to be something SIFT wants to carry.

- Installed as the upstream musl-static binary, from a pinned immutable release tag with an explicit SHA256, to `/usr/local/bin/csvdt`. The rolling `release` tag is deliberately *not* used: its artefacts are rebuilt monthly against a newer IANA tzdata, so its checksum moves and a pin to it would fail `source_hash` on every install after the next rebuild.
- **Guarded to amd64** — upstream publishes no Linux arm64 binary yet. I would rather add `aarch64-unknown-linux-musl` upstream and drop the guard than have SIFT carry an arch gap on my account; say the word and I will do that before this is merged.
- Renovate annotation included: one GitHub-hosted asset with a single digest, which is the case the custom manager in `.github/renovate.json` handles. Checked against that regex as renovate applies it (dotAll, whole file) — it captures `currentValue` and `currentDigest` together, so a bump arrives as a matching pair rather than a new version against a stale hash.
- The manual page is rendered by the binary itself at install time (`--generate-man`), from the same definitions that parse its options, so the page on the image cannot describe an option the installed build lacks. `mandb` is tolerated as absent.
- Registered in `sift/scripts/init.sls` in both the `include:` list and the `test.nop` `require:` list.

Applied in the `saltstack-tester` image on 22.04/3007 and 24.04/3006: three states, none failed, and a second run reports all three `Clean`. The installed binary reports `csvdt 1.0.0+2026.08.8609888 (IANA tzdata 2025b)` and writes a 68 KB man page. `man -w` does not resolve it inside the tester image, but only because that image is a minimized Ubuntu with man-db removed — which is the case the `(mandb -q || true)` tolerance is there for.

License: GPL-3.0-or-later. Source: https://github.com/YardQuit/csvdt
